### PR TITLE
Dark title bar

### DIFF
--- a/Material-Theme-Darker.sublime-theme
+++ b/Material-Theme-Darker.sublime-theme
@@ -3864,6 +3864,11 @@
       "selected_match_fg": [92, 107, 192]
     },
 
+    {
+      "class": "quick_panel_detail_label",
+      "link_color": "#2196F3"
+    },
+
       // Panels data / score
 
     {

--- a/Material-Theme-Darker.sublime-theme
+++ b/Material-Theme-Darker.sublime-theme
@@ -4,57 +4,60 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [
-  //
-  
+  {
+      "class": "title_bar",
+      "style": "dark"
+  },
+
   /* @EMPTY WINDOW
    * Style for empty (no tabs) window
   ========================================================================= */
-  
+
     {
       "class": "sheet_container_control",
       "layer0.tint": [33, 33, 33],
       "layer0.opacity": 1.0
     },
-  
+
   /* @GRID LAYOUT
    * Grid style
   ========================================================================= */
-  
+
     {
       "class": "grid_layout_control",
       "border_size": 1,
       "border_color": [27, 27, 27]
     },
-  
-  
+
+
   /* @DIALOG POPUP
    * Dialog popup style and progressbar
   ========================================================================= */
-  
+
     {
       "class": "progress_gauge_control",
       "layer0.tint": [128, 203, 196],
       "layer0.opacity": 1.0,
       "content_margin": [0, 6]
     },
-  
+
     {
       "class": "dialog",
       "layer0.tint": [33, 33, 33],
       "layer0.opacity": 1.0
     },
-  
+
     {
       "class": "progress_bar_control",
       "layer0.tint": [33, 33, 33],
       "layer0.opacity": 1.0,
     },
-  
-  
+
+
   /* @CODE FOLDING
    * Folding arrow setting and behavioring
   ========================================================================= */
-  
+
     {
       "class": "fold_button_control",
       "layer0.texture": "Material Theme/assets/darker/fold_right.png",
@@ -65,41 +68,41 @@
       "layer1.inner_margin": 0,
       "content_margin": [9, 7, 8, 6]
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["hover"],
       "layer0.opacity": 0.0,
       "layer1.opacity": 1.0
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "layer0.texture": "Material Theme/assets/darker/fold_down.png",
       "layer1.texture": "Material Theme/assets/commons/fold_down--hover.png"
     },
-  
-  
+
+
   /* @AUTOCOMPLETE
    * Autocomplete popup setting and behavioring
   ========================================================================= */
-  
-  
+
+
     {
       "class": "popup_control",
       "layer0.tint": [33, 33, 33],
       "layer0.opacity": 1.0,
       "content_margin": [0, 0]
     },
-  
+
     {
       "class": "auto_complete",
       "row_padding": [12, 6],
       "layer0.tint": [33, 33, 33],
       "layer0.opacity": 1.0
     },
-  
+
     {
       "class": "auto_complete_label",
       "fg": [176, 190, 197, 255],
@@ -107,24 +110,24 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
     {
       "class": "table_row",
       "layer0.tint": [97, 97, 97],
       "layer0.opacity": 0.0,
     },
-  
+
     {
       "class": "table_row",
       "attributes": ["selected"],
       "layer0.opacity": 0.2
     },
-  
-  
+
+
   /* @TOOLTIP
    * Tooltip setting and behavioring
   ========================================================================= */
-  
+
     {
       "class": "tool_tip_control",
       "layer0.tint": [128, 203, 196],
@@ -132,16 +135,16 @@
       "layer0.opacity": 1.0,
       "content_margin": [16, 8]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "color": [0, 0, 0, 150]
     },
-  
+
   /* @OVERLAY PANELS
    * Overlay panels setting and behavioring
   ========================================================================= */
-  
+
     // Command Panel
      {
         "class": "overlay_control",
@@ -153,53 +156,53 @@
         "layer1.opacity": 1.0,
         "content_margin": [13, 13, 13, 33]
      },
-  
+
       // Command Panel list item style (cmd + shift + p)
-  
+
     {
       "class": "mini_quick_panel_row",
       "layer0.tint": [33, 33, 33, 0],
       "layer0.inner_margin": [2, 2, 2, 2],
       "layer0.opacity": 1.0
     },
-  
+
       // Command Panel selected list item style (cmd + p)
-  
+
     {
       "class": "mini_quick_panel_row",
       "attributes": ["selected"],
       "layer0.tint": [66, 66, 66],
       "layer0.opacity": 0.3
     },
-  
+
       // Quick panel project setting (project manager) (cmd + ctrl + p)
-  
+
     {
       "class": "quick_panel",
       "row_padding": [32, 12],
       "layer0.tint": [33, 33, 33],
       "layer0.opacity": 1.0
     },
-  
+
       // Quick Panel row default style (project manager)
-  
+
     {
       "class": "quick_panel_row",
       "layer0.tint": [33, 33, 33, 0],
       "layer0.opacity": 1.0
     },
-  
+
       // Row panel style inside command panel (cmd + shift + p)
-  
+
     {
       "class": "quick_panel_row",
       "parents": [{"class": "overlay_control"}],
       "layer0.tint": [33, 33, 33, 0],
       "layer0.opacity": 1.0
     },
-  
+
       // Quick panel (project) style inside overlay_control (cmd + shift + p)
-  
+
     {
       "class": "quick_panel",
       "parents": [{"class": "overlay_control"}],
@@ -207,9 +210,9 @@
       "layer0.tint": [33, 33, 33, 0],
       "layer0.opacity": 1.0
     },
-  
+
       // Quick Panel selected list item style
-  
+
     {
       "class": "quick_panel_row",
       "attributes": ["selected"],
@@ -217,9 +220,9 @@
       "layer0.opacity": 0.3,
       "layer1.opacity": 0.0
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "fg": [176, 190, 197, 255],
@@ -227,9 +230,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "parents": [{"class": "overlay_control"}],
@@ -238,9 +241,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "fg": [97, 97, 97, 255],
@@ -248,23 +251,23 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "quick_panel_score_label",
       "fg": [176, 190, 197],
       "selected_fg": [255, 255, 255, 255]
     },
-  
-  
+
+
   /* @TABS
    * Tabs settings and behavioring
   ========================================================================= */
-  
+
     {
       "class": "tabset_control",
-  
+
       "layer0.opacity": 1.0,
       "layer0.tint": [33, 33, 33],
       "tint_index": 1,
@@ -277,31 +280,31 @@
       "tab_height": 54,
       "mouse_wheel_switch": false
     },
-  
+
     {
       "class": "tabset_control",
       "settings": ["mouse_wheel_switches_tabs", "!enable_tab_scrolling"],
       "mouse_wheel_switch": true
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
-  
+
       "layer0.tint": [33, 33, 33],
       "layer0.inner_margin": [24, 0],
       "layer0.opacity": 1.0,
       "tint_index": 0,
-  
+
       "layer1.texture": "Material Theme/assets/darker/tab_current.png",
       "layer1.inner_margin": [0, 0],
       "layer1.opacity": 0.0,
-  
+
       "layer2.tint": [255, 255, 255, 0],
       "layer2.inner_margin": [0, 0],
       "layer2.opacity": { "target": 0.0, "speed": 3.0, "interpolation": "smoothstep" },
-  
+
       "layer3.inner_margin": [0, 0],
       "layer3.opacity": { "target": 1.0, "speed": 2.0, "interpolation": "smoothstep" },
       "layer3.texture": {
@@ -324,41 +327,41 @@
               "loop": false,
               "frame_time": 0.015,
       },
-  
+
       "content_margin": [16, 0, 8, 0],
       "max_margin_trim": 0,
       "hit_test_level": 0.4
     },
-  
+
       // Selected current tab
-  
+
     {
       "class": "tab_control", "attributes": ["selected"],
       "layer1.opacity": 1.0,
       "layer2.opacity": 0.0,
       "layer3.opacity": 0.0
     },
-  
+
       // Hovered current tab
-  
+
     {
       "class": "tab_control", "attributes": ["hover"],
       "layer1.opacity": 1.0,
       "layer2.opacity": { "target": 0.6, "speed": 5.0, "interpolation": "smoothstep" },
       "layer3.opacity": { "target": 0.0, "speed": 2.0, "interpolation": "smoothstep" }
     },
-  
+
       // Selected current tab
-  
+
     {
       "class": "tab_control", "attributes": ["selected","hover"],
       "layer1.opacity": 1.0,
       "layer2.opacity": { "target": 0.6, "speed": 5.0, "interpolation": "smoothstep" },
       "layer3.opacity": 0.0
     },
-  
+
       // Tab Labels
-  
+
     {
       "class": "tab_label",
       "fg": [97, 97, 97, 255],
@@ -368,9 +371,9 @@
       "font.italic": false,
       "font.bold": false
     },
-  
+
       // Tab selected label color
-  
+
     {
       "class": "tab_label",
       "parents": [{"class": "tab_control", "attributes": ["selected"]}],
@@ -378,32 +381,32 @@
       "shadow_color": [255, 255, 255, 0],
       "shadow_offset": [0, 0]
     },
-  
+
     {
       "class": "tab_label",
       "attributes": ["transient"],
       "font.italic": true
     },
-  
+
       // Tab Close Buttons
-  
+
     {
       "class": "tab_close_button",
       "content_margin": [0, 0],
-  
+
        // Close Icon
       "layer0.texture": "Material Theme/assets/darker/close_icon.png",
       "layer0.opacity": 1,
       "layer0.inner_margin": 0,
-  
+
       // Close Icon Hover
       "layer1.texture": "Material Theme/assets/commons/close_icon--hover.png",
       "layer1.opacity": { "target": 0.0, "speed": 5.0, "interpolation": "smoothstep" },
-  
+
        // Dirty Icon
       "layer2.texture": "Material Theme/assets/darker/dirty_icon.png",
       "layer2.inner_margin": 0,
-  
+
       // Dirty Icon Hover
       "layer3.texture": "Material Theme/assets/commons/dirty_icon--hover.png",
       "layer3.opacity": { "target": 0.0, "speed": 5.0, "interpolation": "smoothstep" }
@@ -480,13 +483,13 @@
       "layer1.opacity": { "target": 0.0, "speed": 8.0, "interpolation": "smoothstep" },
       "layer1.inner_margin": 0,
     },
-  
+
     {
       "class": "scroll_tabs_left_button",
       "attributes": ["hover"],
       "layer1.opacity": { "target": 1.0, "speed": 8.0, "interpolation": "smoothstep" }
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "content_margin": [14, 7],
@@ -497,13 +500,13 @@
       "layer1.opacity": { "target": 0.0, "speed": 8.0, "interpolation": "smoothstep" },
       "layer1.inner_margin": 0,
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "attributes": ["hover"],
       "layer1.opacity": { "target": 1.0, "speed": 8.0, "interpolation": "smoothstep" }
     },
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "content_margin": [12, 12],
@@ -514,18 +517,18 @@
       "layer1.opacity": { "target": 0.0, "speed": 8.0, "interpolation": "smoothstep" },
       "layer1.inner_margin": 0
     },
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "attributes": ["hover"],
       "layer1.opacity": { "target": 1.0, "speed": 8.0, "interpolation": "smoothstep" }
     },
-  
-  
+
+
   /* @SIDEBAR
    * Sidebar panel settings and behavioring
   ========================================================================= */
-  
+
     {
       "class": "sidebar_container",
       "layer0.tint": [33, 33, 33],
@@ -547,7 +550,7 @@
       "layer1.tint": [0,0,0],
       "layer1.opacity": 0.0
     },
-  
+
     {
       "class": "sidebar_heading",
       "color": [207, 216, 220],
@@ -556,7 +559,7 @@
       "shadow_color": [250, 250, 250, 0],
       "shadow_offset": [0, 0]
     },
-  
+
     {
       "class": "sidebar_heading",
       "parents":
@@ -565,22 +568,22 @@
       ],
       "shadow_color": [160, 174, 192, 0],
     },
-  
+
     {
        "class": "tree_row",
        "layer1.texture": "Material Theme/assets/commons/tree_highlight.png",
        "layer1.opacity": { "target": 0.0, "speed": 5.0, "interpolation": "smoothstep" },
        "layer1.inner_margin": [22, 8, 0, 0]
     },
-  
+
     {
       "class": "tree_row",
       "attributes": ["selected"],
       "layer1.opacity": { "target": 1.0, "speed": 5.0, "interpolation": "smoothstep" }
     },
-  
+
       // Bullet Tree Indicator
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_bullet_tree_indicator"],
@@ -588,7 +591,7 @@
       "layer1.texture": "Material Theme/assets/commons/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "color": [97, 97, 97],
@@ -597,7 +600,7 @@
       "shadow_color": [255, 255, 255, 0],
       "shadow_offset": [0, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["hover"]}],
@@ -605,76 +608,76 @@
       "shadow_color": [255, 255, 255, 0],
       "shadow_offset": [0, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "font.bold": false,
       "color": [128, 203, 196]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expandable"]}],
       "color": [175, 189, 196]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expandable"]}],
       "settings": ["bold_folder_labels"],
       "font.bold": true,
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expandable", "selected"]}],
       "color": [255, 255, 255]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [128, 203, 196]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "settings": ["bold_folder_labels"],
       "font.bold": true
     },
-  
+
     {
       "class": "sidebar_label",
       "attributes": ["transient"],
       "font.italic": false
     },
-  
+
       // File icons and folder
-  
+
     {
       "class": "icon_file_type",
       // layer0.texture is filled in by code with the relevant icon name
       "layer0.opacity": 0.6,
       "content_margin": [9, 9]
     },
-  
+
     {
       "class": "icon_file_type",
       "parents": [{"class": "tree_row", "attributes": ["hover"]}],
       "layer0.opacity": { "target": 1.0, "speed": 3.0, "interpolation": "smoothstep" }
     },
-  
+
     {
       "class": "icon_file_type",
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "layer0.opacity": 1,
       "content_margin": [9, 9]
     },
-  
+
       // Secondary folder icon (original) used as main folder icon
-  
+
     {
       "class": "icon_folder",
       "content_margin": [11, 7],
@@ -687,7 +690,7 @@
       "layer3.texture": "Material Theme/assets/commons/folder_opened--hover.png",
       "layer3.opacity": 0.0,
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -700,7 +703,7 @@
       "layer3.texture": "Material Theme/assets/commons/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "parents":
@@ -711,7 +714,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0,
     },
-  
+
     {
       "class": "icon_folder",
       "parents":
@@ -722,7 +725,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0,
     },
-  
+
     {
       "class": "icon_folder",
       "parents":
@@ -754,7 +757,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0,
     },
-  
+
       // Arrow icon folder Expandend - Hover
     {
       "class": "icon_folder",
@@ -762,8 +765,8 @@
       "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
       "layer3.texture": "Material Theme/assets/commons/arrow_folder--opened.png",
     },
-  
-  
+
+
     {
       "class": "icon_folder",
       "parents":
@@ -772,9 +775,9 @@
       ],
       "layer1.texture": "Material Theme/assets/commons/folder--hover.png",
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "layer0.texture":
@@ -793,35 +796,35 @@
         "loop": true,
         "frame_time": 0.075,
       },
-  
+
       "layer0.opacity": 1.0,
       "content_margin": [8, 8]
     },
-  
+
       // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "layer0.texture": "Material Theme/assets/darker/folder_dup.png",
       "layer0.opacity": 1.0,
       "content_margin": [11, 7]
     },
-  
+
     {
       "class": "icon_folder_dup",
       "parents":
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/commons/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/commons/folder_dup--hover.png"
     },
-  
+
       // Hidden arrow icon before folder
-  
+
     {
       "class": "disclosure_button_control",
       "layer0.texture": "Material Theme/assets/darker/folder.png",
@@ -832,7 +835,7 @@
       "layer1.inner_margin": 0,
       "content_margin": [0, 0, 0, 0]
     },
-  
+
     {
       "class": "disclosure_button_control",
       "parents":
@@ -842,20 +845,20 @@
       "layer0.opacity": 0.0,
       "layer1.opacity": 1.0
     },
-  
+
     {
       "class": "disclosure_button_control",
       "attributes": ["expanded"],
       "layer0.texture": "Material Theme/assets/commons/folder_opened--hover.png",
     },
-  
+
     {
       "class": "tree_row",
       "layer0.tint": [33, 33, 33],
       "layer0.opacity": 0.0,
       "layer0.inner_margin": [1, 1]
     },
-  
+
     {
       "class": "tree_row",
       "attributes": ["selected"],
@@ -865,20 +868,20 @@
     {
       "class": "close_button",
       "content_margin": [8, 8],
-  
+
       // Default Close icon
       "layer0.texture": "Material Theme/assets/darker/close_icon.png",
       "layer0.opacity": { "target": 0.0, "speed": 7.0, "interpolation": "smoothstep" },
       "layer0.inner_margin": [0,0],
-  
+
       // Hover close icon
       "layer1.texture": "Material Theme/assets/commons/close_icon--hover.png",
       "layer1.opacity": 0,
       "layer1.inner_margin": [0,0],
     },
-  
+
       // Opened file hover
-  
+
     {
       "class": "close_button",
       "parents":
@@ -890,28 +893,28 @@
       "layer0.opacity": { "target": 1.0, "speed": 7.0, "interpolation": "smoothstep" },
       "layer0.inner_margin": [0,0],
     },
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "layer0.texture": "Material Theme/assets/commons/dirty_icon--hover.png",
       "layer0.opacity": 1.0,
     },
-  
+
     {
       "class": "close_button",
       "attributes": ["hover"],
       "layer0.opacity": 0,
       "layer1.opacity": 1.0
     },
-  
-  
+
+
   /* @ SCROLLBARS
    * Scrollbars settings and behavioring
   ========================================================================= */
-  
+
       // Normal Vertical scrollbar track
-  
+
     {
       "class": "scroll_bar_control",
       "layer0.tint": [33, 33, 33],
@@ -922,9 +925,9 @@
       "layer1.inner_margin": [0, 6],
       "blur": false
     },
-  
+
       // Normal Vertical scrollbar track inside overlay panel
-  
+
     // {
     //   "class": "scroll_bar_control",
     //   "parents": [{"class": "overlay_control"}],
@@ -933,9 +936,9 @@
     //   "layer0.inner_margin": [0, 6],
     //   "blur": false
     // },
-  
+
       // Normal horizontal scrollbar track
-  
+
     {
       "class": "scroll_bar_control",
       "attributes": ["horizontal"],
@@ -947,9 +950,9 @@
       "layer1.inner_margin": [6, 0],
       "blur": false
     },
-  
+
       // Normal horizontal scrollbar track inside overlay panel
-  
+
     // {
     //     "class": "scroll_bar_control",
     //     "attributes": ["horizontal"],
@@ -959,18 +962,18 @@
     //     "layer0.inner_margin": [0, 2],
     //     "blur": false
     //  },
-  
+
       // Scrollbars corner
-  
+
     {
       "class": "scroll_corner_control",
       "layer0.texture": "Material Theme/assets/darker/normal_bar_corner.png",
       "layer0.opacity": 1.0,
       "layer0.inner_margin": [1, 1]
     },
-  
+
       // Vertical puck controller
-  
+
     {
       "class": "puck_control",
       "layer0.tint": [38, 50, 255, 255],
@@ -982,9 +985,9 @@
       "content_margin": [6, 16],
       "blur": false
     },
-  
+
       // Horizontal puck controller
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -994,34 +997,34 @@
       "content_margin": [16, 6],
       "blur": false
     },
-  
+
     {
       "class": "scroll_area_control",
       "settings": ["overlay_scroll_bars"],
       "overlay": true
     },
-  
+
     {
       "class": "scroll_area_control",
       "settings": ["!overlay_scroll_bars"],
       "overlay": false // set to false for the original behavior
     },
-  
-  
+
+
     {
       "class": "scroll_area_control",
       "parents": [{"class": "overlay_control"}],
       "settings": ["overlay_scroll_bars"],
       "overlay": true // set to false for the original behavior
     },
-  
+
     {
       "class": "scroll_area_control",
       "parents": [{"class": "sidebar_container"}],
       "settings": ["!overlay_scroll_bars"],
       "overlay": false // set to false for the original behavior
     },
-  
+
     {
       "class": "scroll_bar_control",
       "settings": ["overlay_scroll_bars"],
@@ -1029,7 +1032,7 @@
       "layer0.inner_margin": [0, 5],
       "blur": true
     },
-  
+
     {
       "class": "scroll_bar_control",
       "settings": ["overlay_scroll_bars"],
@@ -1042,7 +1045,7 @@
       "layer1.opacity": 0.0,
       "blur": true
     },
-  
+
     {
       "class": "puck_control",
       "layer0.tint": [38, 50, 56],
@@ -1053,7 +1056,7 @@
       "content_margin": [6, 16],
       "blur": true
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -1065,20 +1068,20 @@
       "content_margin": [16, 6],
       "blur": true
     },
-  
-  
+
+
   /* @MINIMAP
    * Minimap settings and behavioring
   ========================================================================= */
-  
-  
+
+
     {
       "class": "minimap_control",
       "settings": ["always_show_minimap_viewport"],
       "viewport_color": [255, 255, 255, 50],
       "viewport_opacity": 0.5,
     },
-  
+
     {
       "class": "minimap_control",
       "settings": ["!always_show_minimap_viewport"],
@@ -1091,15 +1094,15 @@
       "settings": ["!always_show_minimap_viewport"],
       "viewport_opacity": { "target": 0.4, "speed": 20.0, "interpolation": "smoothstep" },
     },
-  
-  
-  
+
+
+
   /* @STATUS BAR
    * Status bar settings and behavioring
   ========================================================================= */
-  
+
     // All labels
-  
+
     {
       "class": "label_control",
       "color": [176, 190, 197],
@@ -1107,37 +1110,37 @@
       "shadow_offset": [0, 0],
       "font.bold": true
     },
-  
+
       // Status bar labels
-  
+
      {
         "class": "label_control",
         "parents": [{"class": "status_bar"}],
         "color": [97, 97, 97, 200],
         "font.bold": false
     },
-  
+
       // Text field labels
-  
+
     {
       "class": "status_bar",
       "content_margin": [8, 0, 0, 0],
-  
+
       // Layer 0 base
       "layer0.tint": [33, 33, 33],
       "layer0.opacity": 1.0,
       "layer0.inner_margin": [2, 2],
-  
+
       // Visible tint layer
       "layer1.tint": [0,0,0],
       "layer1.opacity": 0.0,
     },
-  
+
     {
       "class": "status_container",
       "content_margin": [24, 12, 24, 12],
     },
-  
+
     {
       "class": "status_button",
       "layer0.tint": [33, 33, 33],
@@ -1147,7 +1150,7 @@
       "content_margin": [10, 2, 10, 3],
       "min_size": [75, 0]
     },
-  
+
     {
       "class": "status_button",
       "layer0.tint": [33, 33, 33],
@@ -1157,7 +1160,7 @@
       "content_margin": [10, 2, 10, 3],
       "min_size": [75, 0],
     },
-  
+
     // panel switcher
     {
       "class": "panel_button_control",
@@ -1165,19 +1168,19 @@
       "layer0.opacity": 1.0,
       "content_margin": [10, 10]
     },
-  
+
     {
       "class": "panel_button_control",
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/commons/overflow_menu--hover.png",
     },
-  
-  
+
+
   /* @WIDGET PANEL
    * Widget, input, buttons settings and behavioring
   ========================================================================= */
-  
-  
+
+
     // Status bar panel
     {
       "class": "panel_control",
@@ -1189,9 +1192,9 @@
       "layer1.opacity": 1.0,
       "content_margin": [6, 14, 6, 8],
     },
-  
+
       // Status bar panel close icon
-  
+
     {
       "class": "panel_close_button",
       "layer0.texture": "Material Theme/assets/darker/close_icon.png",
@@ -1200,16 +1203,16 @@
       "layer1.opacity": 0.0,
       "content_margin": [0, 0] // 8,8 to show
     },
-  
+
     {
       "class": "panel_close_button",
       "attributes": ["hover"],
       "layer0.opacity": 0.0,
       "layer1.opacity": 1.0,
     },
-  
+
       // Texline input
-  
+
     {
       "class": "text_line_control",
       "layer0.texture": "Material Theme/assets/darker/input_field_border.png",
@@ -1218,9 +1221,9 @@
       "tint_index": 1,
       "content_margin": [10, 8, 13, 8]
     },
-  
+
       // Textline input inside overlay panels
-  
+
     {
       "class": "text_line_control",
       "parents": [{"class": "overlay_control"}],
@@ -1228,12 +1231,12 @@
       "layer0.opacity": 1.0,
       "layer0.inner_margin": [32, 2, 32, 2],
       "layer0.draw_center": true,
-  
+
       "content_margin": [32, 8, 32, 8]
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "content_margin": [12, 12],
@@ -1249,28 +1252,28 @@
       "attributes": ["hover"],
       "layer1.opacity": 1.0
     },
-  
-  
+
+
   /* @BUTTONS
    * Buttons panels settings and behavioring
   ========================================================================= */
-  
-  
+
+
     // Button labels
-  
+
     {
        "class": "label_control",
        "parents": [{"class": "button_control"}],
        "color": [97, 97, 97],
        "font.bold": true
     },
-  
+
     {
        "class": "label_control",
        "parents": [{"class": "button_control", "attributes": ["hover"]}],
        "color": [255,255,255]
     },
-  
+
     {
       "class": "button_control",
       "content_margin": [6, 12, 6, 12],
@@ -1301,7 +1304,7 @@
       "attributes": ["hover"],
       "layer2.opacity": 1.0
     },
-  
+
     // Small Icon Buttons
     {
       "class": "icon_button_control",
@@ -1312,11 +1315,11 @@
       "layer2.opacity": { "target": 0.0, "speed": 10.0, "interpolation": "smoothstep" },
       "content_margin": [10, 6]
     },
-  
-  
+
+
     /* Buttons icons settings
     ===================================================================== */
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
@@ -1326,16 +1329,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_regex",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "layer0.texture": "Material Theme/assets/commons/find_case--hover.png",
@@ -1344,16 +1347,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_case",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "layer0.texture": "Material Theme/assets/commons/find_word--hover.png",
@@ -1362,17 +1365,17 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
-  
+
+
      {
         "class": "icon_whole_word",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "layer0.texture": "Material Theme/assets/commons/find_wrap--hover.png",
@@ -1381,16 +1384,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_wrap",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "layer0.texture": "Material Theme/assets/commons/find_inselection--hover.png",
@@ -1399,17 +1402,17 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12,12]
     },
-  
-  
+
+
      {
         "class": "icon_in_selection",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "layer0.texture": "Material Theme/assets/commons/find_highlight--hover.png",
@@ -1418,16 +1421,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_highlight",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "layer0.texture": "Material Theme/assets/commons/replace_preserve_case--hover.png",
@@ -1436,16 +1439,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_preserve_case",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "layer0.texture": "Material Theme/assets/commons/find_context--hover.png",
@@ -1454,17 +1457,17 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
-  
+
+
      {
         "class": "icon_context",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "layer0.texture": "Material Theme/assets/commons/use_buffer--hover.png",
@@ -1473,16 +1476,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_use_buffer",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "layer0.texture": "Material Theme/assets/commons/find_reverse--hover.png",
@@ -1491,122 +1494,122 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_reverse",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
-  
+
+
   // Lime Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_lime"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-lime/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_lime"],
       "layer0.tint": [124, 179, 66],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_lime"],
       "layer0.tint": [124, 179, 66],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_lime"],
       "match_fg": [124, 179, 66],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_lime"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_lime", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-lime/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-lime/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_lime"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [124, 179, 66]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [124, 179, 66]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_lime"],
       "layer2.texture": "Material Theme/assets/accent-lime/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-lime/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_lime"],
@@ -1633,9 +1636,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_lime"],
@@ -1656,7 +1659,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_lime"],
@@ -1666,7 +1669,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-lime/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -1676,7 +1679,7 @@
       "layer3.texture": "Material Theme/assets/accent-lime/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1686,7 +1689,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1696,7 +1699,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1706,7 +1709,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1716,37 +1719,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-lime/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_lime"],
@@ -1754,9 +1757,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_lime"],
@@ -1765,9 +1768,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_lime"],
@@ -1775,123 +1778,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_lime"],
       "viewport_color": [124, 179, 66, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -1899,9 +1902,9 @@
       "layer1.texture": "Material Theme/assets/accent-lime/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_lime"],
@@ -1909,121 +1912,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-lime/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-lime/folder_dup--hover.png"
     },
-  
+
   // Purple Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_purple"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-purple/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_purple"],
       "layer0.tint": [171, 71, 188],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_purple"],
       "layer0.tint": [171, 71, 188],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_purple"],
       "match_fg": [171, 71, 188],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_purple"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_purple", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-purple/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-purple/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_purple"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [171, 71, 188]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_purple"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [171, 71, 188]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_purple"],
       "layer2.texture": "Material Theme/assets/accent-purple/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-purple/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_purple"],
@@ -2050,9 +2053,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_purple"],
@@ -2073,7 +2076,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_purple"],
@@ -2083,7 +2086,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-purple/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -2093,7 +2096,7 @@
       "layer3.texture": "Material Theme/assets/accent-purple/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2103,7 +2106,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2113,7 +2116,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2123,7 +2126,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2133,37 +2136,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-purple/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_purple"],
@@ -2171,9 +2174,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_purple"],
@@ -2182,9 +2185,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_purple"],
@@ -2192,123 +2195,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_purple"],
       "viewport_color": [171, 71, 188, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -2316,9 +2319,9 @@
       "layer1.texture": "Material Theme/assets/accent-purple/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_purple"],
@@ -2326,121 +2329,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-purple/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_purple"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-purple/folder_dup--hover.png"
     },
-  
+
   // Red Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_red"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-red/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_red"],
       "layer0.tint": [229, 115, 115],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_red"],
       "layer0.tint": [229, 115, 115],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_red"],
       "match_fg": [229, 115, 115],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_red"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_red", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-red/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-red/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_red"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [229, 115, 115]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_red"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [229, 115, 115]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_red"],
       "layer2.texture": "Material Theme/assets/accent-red/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-red/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_red"],
@@ -2467,9 +2470,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_red"],
@@ -2490,7 +2493,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_red"],
@@ -2500,7 +2503,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-red/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -2510,7 +2513,7 @@
       "layer3.texture": "Material Theme/assets/accent-red/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2520,7 +2523,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2530,7 +2533,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2540,7 +2543,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2550,37 +2553,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-red/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_red"],
@@ -2588,9 +2591,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_red"],
@@ -2599,9 +2602,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_red"],
@@ -2609,123 +2612,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_red"],
       "viewport_color": [229, 115, 115, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -2733,9 +2736,9 @@
       "layer1.texture": "Material Theme/assets/accent-red/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_red"],
@@ -2743,121 +2746,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-red/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_red"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-red/folder_dup--hover.png"
     },
-  
+
   // Orange Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_orange"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-orange/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_orange"],
       "layer0.tint": [255, 112, 66],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_orange"],
       "layer0.tint": [255, 112, 66],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_orange"],
       "match_fg": [255, 112, 66],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_orange"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_orange", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-orange/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-orange/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_orange"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [255, 112, 66]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_orange"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [255, 112, 66]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_orange"],
       "layer2.texture": "Material Theme/assets/accent-orange/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-orange/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_orange"],
@@ -2884,9 +2887,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_orange"],
@@ -2907,7 +2910,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_orange"],
@@ -2917,7 +2920,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-orange/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -2927,7 +2930,7 @@
       "layer3.texture": "Material Theme/assets/accent-orange/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2937,7 +2940,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2947,7 +2950,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2957,7 +2960,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2967,37 +2970,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-orange/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_orange"],
@@ -3005,9 +3008,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_orange"],
@@ -3016,9 +3019,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_orange"],
@@ -3026,123 +3029,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_orange"],
       "viewport_color": [255, 112, 66, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -3150,9 +3153,9 @@
       "layer1.texture": "Material Theme/assets/accent-orange/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_orange"],
@@ -3160,121 +3163,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-orange/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_orange"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-orange/folder_dup--hover.png"
     },
-  
+
   // Yellow Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_yellow"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-yellow/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_yellow"],
       "layer0.tint": [255, 160, 0],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_yellow"],
       "layer0.tint": [255, 160, 0],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_yellow"],
       "match_fg": [255, 160, 0],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_yellow"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_yellow", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-yellow/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-yellow/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_yellow"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [255, 160, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_yellow"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [255, 160, 0]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_yellow"],
       "layer2.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-yellow/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_yellow"],
@@ -3301,9 +3304,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_yellow"],
@@ -3324,7 +3327,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_yellow"],
@@ -3334,7 +3337,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -3344,7 +3347,7 @@
       "layer3.texture": "Material Theme/assets/accent-yellow/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3354,7 +3357,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3364,7 +3367,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3374,7 +3377,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3384,37 +3387,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-yellow/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_yellow"],
@@ -3422,9 +3425,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_yellow"],
@@ -3433,9 +3436,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_yellow"],
@@ -3443,123 +3446,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_yellow"],
       "viewport_color": [255, 160, 0, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -3567,9 +3570,9 @@
       "layer1.texture": "Material Theme/assets/accent-yellow/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_yellow"],
@@ -3577,121 +3580,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-yellow/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_yellow"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-yellow/folder_dup--hover.png"
     },
-  
+
   // Indigo Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_indigo"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-indigo/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_indigo"],
       "layer0.tint": [92, 107, 192],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_indigo"],
       "layer0.tint": [92, 107, 192],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_indigo"],
       "match_fg": [92, 107, 192],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_indigo"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_indigo", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-indigo/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-indigo/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_indigo"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [92, 107, 192]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_indigo"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [92, 107, 192]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_indigo"],
       "layer2.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-indigo/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_indigo"],
@@ -3718,9 +3721,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_indigo"],
@@ -3741,7 +3744,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_indigo"],
@@ -3751,7 +3754,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -3761,7 +3764,7 @@
       "layer3.texture": "Material Theme/assets/accent-indigo/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3771,7 +3774,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3781,7 +3784,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3791,7 +3794,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3801,37 +3804,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-indigo/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_indigo"],
@@ -3839,9 +3842,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_indigo"],
@@ -3850,9 +3853,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_indigo"],
@@ -3860,123 +3863,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_indigo"],
       "viewport_color": [92, 107, 192, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -3984,9 +3987,9 @@
       "layer1.texture": "Material Theme/assets/accent-indigo/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_indigo"],
@@ -3994,121 +3997,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-indigo/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_indigo"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-indigo/folder_dup--hover.png"
     },
-  
+
   // Pink Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_pink"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-pink/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_pink"],
       "layer0.tint": [255, 64, 129],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_pink"],
       "layer0.tint": [255, 64, 129],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_pink"],
       "match_fg": [255, 64, 129],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_pink"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_pink", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-pink/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-pink/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_pink"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [255, 64, 129]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_pink"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [255, 64, 129]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_pink"],
       "layer2.texture": "Material Theme/assets/accent-pink/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-pink/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_pink"],
@@ -4135,9 +4138,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_pink"],
@@ -4158,7 +4161,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_pink"],
@@ -4168,7 +4171,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-pink/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -4178,7 +4181,7 @@
       "layer3.texture": "Material Theme/assets/accent-pink/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4188,7 +4191,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4198,7 +4201,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4208,7 +4211,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4218,37 +4221,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-pink/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_pink"],
@@ -4256,9 +4259,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_pink"],
@@ -4267,9 +4270,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_pink"],
@@ -4277,123 +4280,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_pink"],
       "viewport_color": [255, 64, 129, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -4401,9 +4404,9 @@
       "layer1.texture": "Material Theme/assets/accent-pink/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_pink"],
@@ -4411,121 +4414,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-pink/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_pink"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-pink/folder_dup--hover.png"
     },
-  
+
   // Blue Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_blue"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-blue/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_blue"],
       "layer0.tint": [41, 121, 255],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_blue"],
       "layer0.tint": [41, 121, 255],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_blue"],
       "match_fg": [41, 121, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_blue"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_blue", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-blue/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-blue/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_blue"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [41, 121, 255]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_blue"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [41, 121, 255]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_blue"],
       "layer2.texture": "Material Theme/assets/accent-blue/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-blue/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_blue"],
@@ -4552,9 +4555,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_blue"],
@@ -4575,7 +4578,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_blue"],
@@ -4585,7 +4588,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-blue/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -4595,7 +4598,7 @@
       "layer3.texture": "Material Theme/assets/accent-blue/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4605,7 +4608,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4615,7 +4618,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4625,7 +4628,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4635,37 +4638,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-blue/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_blue"],
@@ -4673,9 +4676,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_blue"],
@@ -4684,9 +4687,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_blue"],
@@ -4694,123 +4697,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_blue"],
       "viewport_color": [41, 121, 255, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -4818,9 +4821,9 @@
       "layer1.texture": "Material Theme/assets/accent-blue/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_blue"],
@@ -4828,121 +4831,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-blue/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_blue"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-blue/folder_dup--hover.png"
     },
-  
+
   // Cyan Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_cyan"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-cyan/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_cyan"],
       "layer0.tint": [0, 188, 212],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_cyan"],
       "layer0.tint": [0, 188, 212],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_cyan"],
       "match_fg": [0, 188, 212],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_cyan"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_cyan", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-cyan/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-cyan/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_cyan"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [0, 188, 212]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_cyan"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [0, 188, 212]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_cyan"],
       "layer2.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-cyan/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_cyan"],
@@ -4969,9 +4972,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_cyan"],
@@ -4992,7 +4995,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_cyan"],
@@ -5002,7 +5005,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -5012,7 +5015,7 @@
       "layer3.texture": "Material Theme/assets/accent-cyan/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5022,7 +5025,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5032,7 +5035,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5042,7 +5045,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5052,37 +5055,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-cyan/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_cyan"],
@@ -5090,9 +5093,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_cyan"],
@@ -5101,9 +5104,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_cyan"],
@@ -5111,123 +5114,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_cyan"],
       "viewport_color": [0, 188, 212, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -5235,9 +5238,9 @@
       "layer1.texture": "Material Theme/assets/accent-cyan/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_cyan"],
@@ -5245,121 +5248,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-cyan/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_cyan"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-cyan/folder_dup--hover.png"
     },
-  
+
   // Bright Teal Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_bright-teal"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.tint": [100, 255, 218],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.tint": [100, 255, 218],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_bright-teal"],
       "match_fg": [100, 255, 218],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_bright-teal"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_bright-teal", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-bright-teal/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_bright-teal"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [100, 255, 218]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_bright-teal"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [100, 255, 218]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_bright-teal"],
       "layer2.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-bright-teal/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5386,9 +5389,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5409,7 +5412,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5419,7 +5422,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -5429,7 +5432,7 @@
       "layer3.texture": "Material Theme/assets/accent-bright-teal/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5439,7 +5442,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5449,7 +5452,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5459,7 +5462,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5469,37 +5472,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5507,9 +5510,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5518,9 +5521,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5528,123 +5531,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_bright-teal"],
       "viewport_color": [100, 255, 218, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -5652,9 +5655,9 @@
       "layer1.texture": "Material Theme/assets/accent-bright-teal/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5662,121 +5665,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_bright-teal"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/folder_dup--hover.png"
     },
-  
+
   // Acid Lime Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_acid-lime"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.tint": [198, 255, 0],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.tint": [198, 255, 0],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_acid-lime"],
       "match_fg": [198, 255, 0],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_acid-lime"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_acid-lime", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-acid-lime/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_acid-lime"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [198, 255, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_acid-lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [198, 255, 0]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_acid-lime"],
       "layer2.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-acid-lime/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5803,9 +5806,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5826,7 +5829,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5836,7 +5839,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -5846,7 +5849,7 @@
       "layer3.texture": "Material Theme/assets/accent-acid-lime/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5856,7 +5859,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5866,7 +5869,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5876,7 +5879,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5886,37 +5889,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5924,9 +5927,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5935,9 +5938,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5945,123 +5948,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_acid-lime"],
       "viewport_color": [198, 255, 0, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -6069,9 +6072,9 @@
       "layer1.texture": "Material Theme/assets/accent-acid-lime/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_acid-lime"],
@@ -6079,121 +6082,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_acid-lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/folder_dup--hover.png"
     },
-  
+
   // Graphite Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_graphite"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-graphite/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_graphite"],
       "layer0.tint": [97, 97, 97],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_graphite"],
       "layer0.tint": [97, 97, 97],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_graphite"],
       "match_fg": [97, 97, 97],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_graphite"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_graphite", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-graphite/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-graphite/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_graphite"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [97, 97, 97]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_graphite"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [97, 97, 97]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_graphite"],
       "layer2.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-graphite/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_graphite"],
@@ -6220,9 +6223,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_graphite"],
@@ -6243,7 +6246,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_graphite"],
@@ -6253,7 +6256,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -6263,7 +6266,7 @@
       "layer3.texture": "Material Theme/assets/accent-graphite/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6273,7 +6276,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6283,7 +6286,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6293,7 +6296,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6303,37 +6306,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-graphite/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_graphite"],
@@ -6341,9 +6344,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_graphite"],
@@ -6352,9 +6355,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_graphite"],
@@ -6362,123 +6365,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_graphite"],
       "viewport_color": [97, 97, 97, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -6486,9 +6489,9 @@
       "layer1.texture": "Material Theme/assets/accent-graphite/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_graphite"],
@@ -6496,121 +6499,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-graphite/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_graphite"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-graphite/folder_dup--hover.png"
     },
-  
+
   // Breaking Bad Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_brba"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-brba/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_brba"],
       "layer0.tint": [56, 142, 60],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_brba"],
       "layer0.tint": [56, 142, 60],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_brba"],
       "match_fg": [56, 142, 60],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_brba"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_brba", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-brba/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-brba/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_brba"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [56, 142, 60]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_brba"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [56, 142, 60]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_brba"],
       "layer2.texture": "Material Theme/assets/accent-brba/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-brba/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_brba"],
@@ -6637,9 +6640,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_brba"],
@@ -6660,7 +6663,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_brba"],
@@ -6670,7 +6673,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-brba/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -6680,7 +6683,7 @@
       "layer3.texture": "Material Theme/assets/accent-brba/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6690,7 +6693,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6700,7 +6703,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6710,7 +6713,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6720,37 +6723,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-brba/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_brba"],
@@ -6758,9 +6761,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_brba"],
@@ -6769,9 +6772,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_brba"],
@@ -6779,123 +6782,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_brba"],
       "viewport_color": [56, 142, 60, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -6903,9 +6906,9 @@
       "layer1.texture": "Material Theme/assets/accent-brba/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_brba"],
@@ -6913,121 +6916,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-brba/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_brba"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-brba/folder_dup--hover.png"
     },
-  
+
   // Sky Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_sky"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-sky/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_sky"],
       "layer0.tint": [132, 255, 255],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_sky"],
       "layer0.tint": [132, 255, 255],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_sky"],
       "match_fg": [132, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_sky"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_sky", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-sky/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-sky/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_sky"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [132, 255, 255]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_sky"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [132, 255, 255]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_sky"],
       "layer2.texture": "Material Theme/assets/accent-sky/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-sky/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_sky"],
@@ -7054,9 +7057,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_sky"],
@@ -7077,7 +7080,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_sky"],
@@ -7087,7 +7090,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-sky/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -7097,7 +7100,7 @@
       "layer3.texture": "Material Theme/assets/accent-sky/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7107,7 +7110,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7117,7 +7120,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7127,7 +7130,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7137,37 +7140,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-sky/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_sky"],
@@ -7175,9 +7178,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_sky"],
@@ -7186,9 +7189,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_sky"],
@@ -7196,123 +7199,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_sky"],
       "viewport_color": [132, 255, 255, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -7320,9 +7323,9 @@
       "layer1.texture": "Material Theme/assets/accent-sky/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_sky"],
@@ -7330,121 +7333,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-sky/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_sky"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-sky/folder_dup--hover.png"
     },
-  
+
   // Tomato Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_tomato"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-tomato/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_tomato"],
       "layer0.tint": [244, 67, 54],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_tomato"],
       "layer0.tint": [244, 67, 54],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_tomato"],
       "match_fg": [244, 67, 54],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_tomato"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_tomato", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-tomato/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-tomato/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_tomato"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [244, 67, 54]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_tomato"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [244, 67, 54]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_tomato"],
       "layer2.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-tomato/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_tomato"],
@@ -7471,9 +7474,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_tomato"],
@@ -7494,7 +7497,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_tomato"],
@@ -7504,7 +7507,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -7514,7 +7517,7 @@
       "layer3.texture": "Material Theme/assets/accent-tomato/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7524,7 +7527,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7534,7 +7537,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7544,7 +7547,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7554,37 +7557,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-tomato/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_tomato"],
@@ -7592,9 +7595,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_tomato"],
@@ -7603,9 +7606,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_tomato"],
@@ -7613,123 +7616,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_tomato"],
       "viewport_color": [244, 67, 54, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -7737,9 +7740,9 @@
       "layer1.texture": "Material Theme/assets/accent-tomato/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_tomato"],
@@ -7747,47 +7750,47 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-tomato/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_tomato"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-tomato/folder_dup--hover.png"
     },
-  
-  
-  
+
+
+
   // @ THEME OPTIONS
   // Options override
   // =========================================================================
-  
+
     // Tabs size Settings
-  
+
     {
       "class": "tabset_control",
       "settings": ["material_theme_small_tab"],
       "tab_height": 36,
       "content_margin": [12, 0, 8, 0]
     },
-  
+
     {
       "class": "tabset_control",
       "settings": ["material_theme_tabs_autowidth"],
       "tab_width": 0
     },
-  
+
     {
       "class": "tabset_control",
       "settings": ["!enable_tab_scrolling"],
       "content_margin": [0, 0, 8, 0],
     },
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_small_tab"],
       "content_margin": [12, 8, 6, 4],
     },
-  
+
     // Tabs separator
     {
       "class": "tab_control",
@@ -7796,17 +7799,17 @@
       "layer3.inner_margin": [1, 1],
       "layer3.opacity": 1.0,
     },
-  
+
       // Tab Labels
-  
+
     {
       "class": "tab_label",
       "settings": ["material_theme_bold_tab"],
       "font.bold": true
     },
-  
+
       // Disable Folder animation
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation"],
@@ -7815,9 +7818,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/commons/folder--hover.png",
     },
-  
+
       // Disable Folder animation
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders"],
@@ -7826,11 +7829,11 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/commons/arrow_folder--opened.png",
     },
-  
+
       // Folder hover no animation
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_lime"],
@@ -7839,7 +7842,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-lime/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -7848,9 +7851,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-lime/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_purple"],
@@ -7859,7 +7862,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-purple/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -7868,9 +7871,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-purple/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_red"],
@@ -7879,7 +7882,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-red/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_red"],
@@ -7888,9 +7891,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-red/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_orange"],
@@ -7899,7 +7902,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-orange/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -7908,9 +7911,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-orange/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_yellow"],
@@ -7919,7 +7922,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -7928,9 +7931,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-yellow/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_indigo"],
@@ -7939,7 +7942,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -7948,9 +7951,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-indigo/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_pink"],
@@ -7959,7 +7962,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-pink/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -7968,9 +7971,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-pink/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_blue"],
@@ -7979,7 +7982,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-blue/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -7988,9 +7991,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-blue/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_cyan"],
@@ -7999,7 +8002,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -8008,9 +8011,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-cyan/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_bright-teal"],
@@ -8019,7 +8022,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -8028,9 +8031,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-bright-teal/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_acid-lime"],
@@ -8039,7 +8042,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -8048,9 +8051,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-acid-lime/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_graphite"],
@@ -8059,7 +8062,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -8068,9 +8071,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-graphite/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_brba"],
@@ -8079,7 +8082,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-brba/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -8088,9 +8091,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-brba/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_sky"],
@@ -8099,7 +8102,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-sky/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -8108,9 +8111,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-sky/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_tomato"],
@@ -8119,7 +8122,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -8128,26 +8131,26 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-tomato/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
       // Small status bar
-  
+
     {
       "class": "status_container",
       "settings": ["material_theme_small_statusbar"],
       "content_margin": [12, 6, 12, 6],
     },
-  
+
       // Tree Indicator
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_disable_tree_indicator"],
       "attributes": ["selected"],
       "layer1.opacity": 0.0
     },
-  
+
     // Status bar panel
     {
       "class": "panel_control",
@@ -8156,74 +8159,74 @@
       "layer1.opacity": 0.2,
       "layer1.inner_margin": [2, 2, 2, 2],
     },
-  
+
       // Contrast mode
-  
+
     {
       "class": "sidebar_container",
       "settings": ["material_theme_contrast_mode"],
       "layer1.opacity": 0.2
     },
-  
+
     {
       "class": "sidebar_tree",
       "settings": ["material_theme_contrast_mode"],
       "layer1.opacity": 0.2
     },
-  
+
     {
       "class": "status_bar",
       "settings": ["material_theme_contrast_mode"],
       "layer1.opacity": 0.2
     },
-  
+
       // Compact mode
-  
+
     {
       "class": "sidebar_tree",
       "settings": ["material_theme_compact_sidebar"],
       "row_padding": [24, 5]
     },
-  
+
     {
       "class": "panel_control",
       "settings": ["material_theme_compact_panel"],
       "content_margin": [0, 0, 0, 0],
     },
-  
+
       // Filetype icons in sidebar
-  
+
     {
       "class": "icon_file_type",
       "settings": ["material_theme_disable_fileicons"],
       "layer0.opacity": 0,
       "content_margin": [0, 0]
     },
-  
+
       // Bigger file_type icons
-  
+
     {
       "class": "icon_file_type",
       "settings": ["material_theme_big_fileicons"],
       "content_margin": [11, 11]
     },
-  
+
     {
       "class": "icon_file_type",
       "settings": ["material_theme_big_fileicons"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "content_margin": [11, 11]
     },
-  
+
         // Bright scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_bright_scrollbars"],
       "layer1.texture": "Material Theme/assets/commons/thumb_vertical.png",
       "layer1.opacity": 0.2
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -8231,9 +8234,9 @@
       "layer1.texture": "Material Theme/assets/commons/thumb_horizontal.png",
       "layer1.opacity": 0.2
     },
-  
+
       // Title bar (OS X 10.10+)
-  
+
     {
       "class": "title_bar",
       "settings": ["material_theme_titlebar"],
@@ -8241,214 +8244,214 @@
       "fg": [97, 97, 97],
       "bg": [33, 33, 33]
     },
-  
+
     {
       "class": "title_bar",
       "settings": ["material_theme_titlebar", "material_theme_contrast_mode"],
       "platforms": ["osx"],
       "fg": [97, 97, 97],
       "bg":
-        
+
           [26, 26, 26]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_lime", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [124, 179, 66],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_purple", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [171, 71, 188],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_red", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [229, 115, 115],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_orange", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [255, 112, 66],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_yellow", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [255, 160, 0],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_indigo", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [92, 107, 192],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_pink", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [255, 64, 129],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_blue", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [41, 121, 255],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_cyan", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [0, 188, 212],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_bright-teal", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [100, 255, 218],
       "fg":
-        
+
           [0, 0, 0]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_acid-lime", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [198, 255, 0],
       "fg":
-        
+
           [0, 0, 0]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_graphite", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [97, 97, 97],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_brba", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [56, 142, 60],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_sky", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [132, 255, 255],
       "fg":
-        
+
           [0, 0, 0]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_tomato", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [244, 67, 54],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
   //
 ]

--- a/Material-Theme-Lighter.sublime-theme
+++ b/Material-Theme-Lighter.sublime-theme
@@ -5,56 +5,56 @@
 
 [
   //
-  
+
   /* @EMPTY WINDOW
    * Style for empty (no tabs) window
   ========================================================================= */
-  
+
     {
       "class": "sheet_container_control",
       "layer0.tint": [250, 250, 250],
       "layer0.opacity": 1.0
     },
-  
+
   /* @GRID LAYOUT
    * Grid style
   ========================================================================= */
-  
+
     {
       "class": "grid_layout_control",
       "border_size": 1,
       "border_color": [230, 230, 230]
     },
-  
-  
+
+
   /* @ DIALOG POPUP
    * Dialog popup style and progressbar
   ========================================================================= */
-  
+
     {
       "class": "progress_gauge_control",
       "layer0.tint": [128, 203, 196],
       "layer0.opacity": 1.0,
       "content_margin": [0, 6]
     },
-  
+
     {
       "class": "dialog",
       "layer0.tint": [250, 250, 250],
       "layer0.opacity": 1.0
     },
-  
+
     {
       "class": "progress_bar_control",
       "layer0.tint": [250, 250, 250],
       "layer0.opacity": 1.0,
     },
-  
-  
+
+
   /* @ CODE FOLDING
    * Folding arrow setting and behavioring
   ========================================================================= */
-  
+
     {
       "class": "fold_button_control",
       "layer0.texture": "Material Theme/assets/lighter/fold_right.png",
@@ -65,42 +65,42 @@
       "layer1.inner_margin": 0,
       "content_margin": [9, 7, 8, 6]
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["hover"],
       "layer0.opacity": 0.0,
       "layer1.opacity": 1.0
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "layer0.texture": "Material Theme/assets/lighter/fold_down.png",
       "layer1.texture": "Material Theme/assets/commons/fold_down--hover.png"
     },
-  
-  
+
+
   /* @ AUTOCOMPLETE
    * Autocomplete popup setting and behavioring
   ========================================================================= */
-  
-  
+
+
     {
       "class": "popup_control",
       "layer0.texture": [255, 255, 255, 255],
       "layer0.opacity": 1.0,
       "content_margin": [0, 0]
     },
-  
+
     {
       "class": "auto_complete",
       "row_padding": [12, 6],
       "layer0.tint": [255, 255, 255],
       "layer0.opacity": 1.0
     },
-  
-  
+
+
     {
       "class": "auto_complete_label",
       "fg": [84, 110, 122, 255],
@@ -108,24 +108,24 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
     {
       "class": "table_row",
       "layer0.tint": [84, 110, 122],
       "layer0.opacity": 0.0,
     },
-  
+
     {
       "class": "table_row",
       "attributes": ["selected"],
       "layer0.opacity": 1.0
     },
-  
-  
+
+
   /* @ TOOLTIP
    * Tooltip setting and behavioring
   ========================================================================= */
-  
+
     {
       "class": "tool_tip_control",
       "layer0.tint": [128, 203, 196],
@@ -133,17 +133,17 @@
       "layer0.opacity": 1.0,
       "content_margin": [16, 8]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "color": [0, 0, 0, 150]
     },
-  
-  
+
+
   /* @OVERLAY PANELS
    * Overlay panels setting and behavioring
   ========================================================================= */
-  
+
     // Command Panel
     {
       "class": "overlay_control",
@@ -155,52 +155,52 @@
       "layer1.opacity": 1.0,
       "content_margin": [13, 13, 13, 33]
     },
-  
+
       // Command Panel list item style (cmd + shift + p)
-  
+
     {
       "class": "mini_quick_panel_row",
       "layer0.tint": [250, 250, 250],
       "layer0.inner_margin": [2, 2, 2, 2],
       "layer0.opacity": 1.0
     },
-  
+
       // Command Panel selected list item style (cmd + p)
-  
+
     {
       "class": "mini_quick_panel_row",
       "attributes": ["selected"],
       "layer0.tint": [144, 164, 174]
     },
-  
+
       // Quick panel project setting (project manager) (cmd + ctrl + p)
-  
+
     {
       "class": "quick_panel",
       "row_padding": [32, 12],
       "layer0.tint": [250, 250, 250],
       "layer0.opacity": 1.0
     },
-  
+
       // Quick Panel row default style (project manager)
-  
+
     {
       "class": "quick_panel_row",
       "layer0.tint": [38, 50, 56, 0],
       "layer0.opacity": 1.0
     },
-  
+
       // Row panel style inside command panel (cmd + shift + p)
-  
+
     {
       "class": "quick_panel_row",
       "parents": [{"class": "overlay_control"}],
       "layer0.tint": [250, 250, 250],
       "layer0.opacity": 1.0
     },
-  
+
       // Quick panel (project) style inside overlay_control (cmd + shift + p)
-  
+
     {
       "class": "quick_panel",
       "parents": [{"class": "overlay_control"}],
@@ -208,18 +208,18 @@
       "layer0.tint": [38, 50, 56, 0],
       "layer0.opacity": 1.0
     },
-  
+
       // Quick Panel selected list item style
-  
+
     {
       "class": "quick_panel_row",
       "attributes": ["selected"],
       "layer0.tint": [144, 164, 174],
       "layer1.opacity": 0.0
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "fg": [128, 203, 196, 255],
@@ -227,9 +227,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "parents": [{"class": "overlay_control"}],
@@ -238,9 +238,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "fg": [176, 190, 197, 255],
@@ -248,20 +248,20 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "quick_panel_score_label",
       "fg": [84, 110, 122],
       "selected_fg": [255, 255, 255, 255]
     },
-  
-  
+
+
   /* @ TABS
    * Tabs settings and behavioring
   ========================================================================= */
-  
+
     {
       "class": "tabset_control",
       "layer0.opacity": 1.0,
@@ -284,21 +284,21 @@
       // Tabs
     {
       "class": "tab_control",
-  
+
       "layer0.tint": [250, 250, 250],
       "layer0.inner_margin": [24, 0],
       "layer0.opacity": 1.0,
       "tint_index": 0,
-  
+
       "layer1.texture": "Material Theme/assets/lighter/tab_current.png",
       "layer1.inner_margin": [0, 0],
       "layer1.opacity": 0.0,
-  
+
       "layer2.tint": [128, 203, 196, 0],
       "layer2.inner_margin": [0, 0],
       "layer2.opacity": { "target": 0.0, "speed": 3.0, "interpolation": "smoothstep" },
-  
-  
+
+
       "layer3.inner_margin": [0, 0],
       "layer3.opacity": { "target": 1.0, "speed": 2.0, "interpolation": "smoothstep" },
       "layer3.texture": {
@@ -321,41 +321,41 @@
               "loop": false,
               "frame_time": 0.015,
       },
-  
+
       "content_margin": [16, 0, 8, 0],
       "max_margin_trim": 0,
       "hit_test_level": 0.4
     },
-  
+
       // Selected current tab
-  
+
     {
       "class": "tab_control", "attributes": ["selected"],
       "layer1.opacity": 1.0,
       "layer2.opacity": 0.0,
       "layer3.opacity": 0.0
     },
-  
+
       // Hovered current tab
-  
+
     {
       "class": "tab_control", "attributes": ["hover"],
       "layer1.opacity": 1.0,
       "layer2.opacity": { "target": 0.8, "speed": 5.0, "interpolation": "smoothstep" },
       "layer3.opacity": { "target": 0.0, "speed": 2.0, "interpolation": "smoothstep" }
     },
-  
+
       // Selected current tab
-  
+
     {
       "class": "tab_control", "attributes": ["selected","hover"],
       "layer1.opacity": 1.0,
       "layer2.opacity": { "target": 0.8, "speed": 5.0, "interpolation": "smoothstep" },
       "layer3.opacity": 0.0
     },
-  
+
       // Tab Labels
-  
+
     {
       "class": "tab_label",
       "fg": [176, 190, 197, 255],
@@ -365,9 +365,9 @@
       "font.italic": false,
       "font.bold": false
     },
-  
+
       // Tab selected label color
-  
+
     {
       "class": "tab_label",
       "parents": [{"class": "tab_control", "attributes": ["selected"]}],
@@ -376,36 +376,36 @@
       "shadow_color": [255, 255, 255, 0],
       "shadow_offset": [0, 0]
     },
-  
+
     {
       "class": "tab_label",
       "attributes": ["transient"],
       "font.italic": true
     },
-  
+
       // Tab Close Buttons
     {
       "class": "tab_close_button",
       "content_margin": [0, 0],
-  
+
        // Close Icon
       "layer0.texture": "Material Theme/assets/lighter/close_icon.png",
       "layer0.opacity": 1,
       "layer0.inner_margin": 0,
-  
+
       // Close Icon Hover
       "layer1.texture": "Material Theme/assets/commons/close_icon--hover.png",
       "layer1.opacity": { "target": 0.0, "speed": 5.0, "interpolation": "smoothstep" },
-  
+
        // Dirty Icon
       "layer2.texture": "Material Theme/assets/lighter/dirty_icon.png",
       "layer2.inner_margin": 0,
-  
+
       // Dirty Icon Hover
       "layer3.texture": "Material Theme/assets/commons/dirty_icon--hover.png",
       "layer3.opacity": { "target": 0.0, "speed": 5.0, "interpolation": "smoothstep" }
     },
-  
+
       // Default
     {
       "class": "tab_close_button",
@@ -438,7 +438,7 @@
       "layer3.opacity": 1, // Dirty Icon Hover
       "content_margin": [8,8],
     },
-  
+
       // Dirty tab on hover
     {
       "class": "tab_close_button",
@@ -479,13 +479,13 @@
       "layer1.opacity": { "target": 0.0, "speed": 8.0, "interpolation": "smoothstep" },
       "layer1.inner_margin": 0,
     },
-  
+
     {
       "class": "scroll_tabs_left_button",
       "attributes": ["hover"],
       "layer1.opacity": { "target": 1.0, "speed": 8.0, "interpolation": "smoothstep" }
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "content_margin": [14, 7],
@@ -496,13 +496,13 @@
       "layer1.opacity": { "target": 0.0, "speed": 8.0, "interpolation": "smoothstep" },
       "layer1.inner_margin": 0,
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "attributes": ["hover"],
       "layer1.opacity": { "target": 1.0, "speed": 8.0, "interpolation": "smoothstep" }
     },
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "content_margin": [12, 12],
@@ -513,18 +513,18 @@
       "layer1.opacity": { "target": 0.0, "speed": 8.0, "interpolation": "smoothstep" },
       "layer1.inner_margin": 0,
     },
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "attributes": ["hover"],
       "layer1.opacity": { "target": 1.0, "speed": 8.0, "interpolation": "smoothstep" }
     },
-  
-  
+
+
   /* @ SIDEBAR
    * Sidebar panel settings and behavioring
   ========================================================================= */
-  
+
     {
       "class": "sidebar_container",
       "layer0.tint": [250, 250, 250],
@@ -546,7 +546,7 @@
       "layer1.tint": [225,225,225],
       "layer1.opacity": 0.0
     },
-  
+
     {
       "class": "sidebar_heading",
       "color": [207, 216, 220],
@@ -555,7 +555,7 @@
       "shadow_color": [250, 250, 250, 0],
       "shadow_offset": [0, 0],
     },
-  
+
     {
       "class": "sidebar_heading",
       "parents":
@@ -564,22 +564,22 @@
       ],
       "shadow_color": [160, 174, 192, 0],
     },
-  
+
     {
        "class": "tree_row",
        "layer1.texture": "Material Theme/assets/commons/tree_highlight.png",
        "layer1.opacity": { "target": 0.0, "speed": 5.0, "interpolation": "smoothstep" },
        "layer1.inner_margin": [22, 8, 0, 0]
     },
-  
+
     {
        "class": "tree_row",
        "attributes": ["selected"],
        "layer1.opacity": { "target": 1.0, "speed": 5.0, "interpolation": "smoothstep" }
     },
-  
+
       // Bullet Tree Indicator
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_bullet_tree_indicator"],
@@ -587,7 +587,7 @@
       "layer1.texture": "Material Theme/assets/commons/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "color": [176, 190, 197],
@@ -596,7 +596,7 @@
       "shadow_color": [255, 255, 255, 0],
       "shadow_offset": [0, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["hover"]}],
@@ -604,83 +604,83 @@
       "shadow_color": [255, 255, 255, 0],
       "shadow_offset": [0, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "font.bold": false,
       "color": [69, 90, 100]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expandable"]}],
       "color": [144, 164, 174]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expandable"]}],
       "settings": ["bold_folder_labels"],
       "font.bold": true
     },
-  
-  
+
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expandable", "selected"]}],
       "color": [69, 90, 100]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [128, 203, 196]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "settings": ["bold_folder_labels"],
       "font.bold": true
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expanded", "selected"]}],
       "color": [69, 90, 100]
     },
-  
+
     {
       "class": "sidebar_label",
       "attributes": ["transient"],
       "font.italic": false
     },
-  
+
       // File icons and folder
-  
+
     {
       "class": "icon_file_type",
       // layer0.texture is filled in by code with the relevant icon name
       "layer0.opacity": 0.6,
       "content_margin": [9, 9]
     },
-  
+
     {
       "class": "icon_file_type",
       "parents": [{"class": "tree_row", "attributes": ["hover"]}],
       "layer0.opacity": { "target": 1.0, "speed": 3.0, "interpolation": "smoothstep" }
     },
-  
+
     {
       "class": "icon_file_type",
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "layer0.opacity": 1,
       "content_margin": [9, 9]
     },
-  
+
       // Secondary folder icon (original) used as main folder icon
-  
+
     {
       "class": "icon_folder",
       "content_margin": [11, 7],
@@ -693,7 +693,7 @@
       "layer3.texture": "Material Theme/assets/commons/folder_opened--hover.png",
       "layer3.opacity": 0.0,
     },
-  
+
         // Arrow icon folder
     {
       "class": "icon_folder",
@@ -706,7 +706,7 @@
       "layer3.texture": "Material Theme/assets/commons/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "parents":
@@ -717,7 +717,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0,
     },
-  
+
     {
       "class": "icon_folder",
       "parents":
@@ -728,7 +728,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0,
     },
-  
+
     {
       "class": "icon_folder",
       "parents":
@@ -760,7 +760,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0,
     },
-  
+
       // Arrow icon folder Expandend - Hover
     {
       "class": "icon_folder",
@@ -768,8 +768,8 @@
       "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
       "layer3.texture": "Material Theme/assets/commons/arrow_folder--opened.png",
     },
-  
-  
+
+
     {
       "class": "icon_folder",
       "parents":
@@ -778,9 +778,9 @@
       ],
       "layer1.texture": "Material Theme/assets/commons/folder--hover.png",
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "layer0.texture":
@@ -803,35 +803,35 @@
         "loop": true,
         "frame_time": 0.075,
       },
-  
+
       "layer0.opacity": 1.0,
       "content_margin": [8, 8]
     },
-  
+
       // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "layer0.texture": "Material Theme/assets/lighter/folder_dup.png",
       "layer0.opacity": 1.0,
       "content_margin": [11, 7]
     },
-  
+
     {
       "class": "icon_folder_dup",
       "parents":
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/commons/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/commons/folder_dup--hover.png"
     },
-  
+
       // Hidden arrow icon before folder
-  
+
     {
       "class": "disclosure_button_control",
       "layer0.texture": "Material Theme/assets/lighter/folder.png",
@@ -842,7 +842,7 @@
       "layer1.inner_margin": 0,
       "content_margin": [0, 0, 0, 0]
     },
-  
+
     {
       "class": "disclosure_button_control",
       "parents":
@@ -852,20 +852,20 @@
       "layer0.opacity": 0.0,
       "layer1.opacity": 1.0
     },
-  
+
     {
       "class": "disclosure_button_control",
       "attributes": ["expanded"],
       "layer0.texture": "Material Theme/assets/commons/folder_opened--hover.png",
     },
-  
+
     {
       "class": "tree_row",
       "layer0.tint": [250, 250, 250],
       "layer0.opacity": 0.0,
       "layer0.inner_margin": [1, 1]
     },
-  
+
     {
       "class": "tree_row",
       "attributes": ["selected"],
@@ -875,20 +875,20 @@
     {
       "class": "close_button",
       "content_margin": [8, 8],
-  
+
       // Default Close icon
       "layer0.texture": "Material Theme/assets/lighter/close_icon.png",
       "layer0.opacity": { "target": 0.0, "speed": 7.0, "interpolation": "smoothstep" },
       "layer0.inner_margin": [0,0],
-  
+
       // Hover close icon
       "layer1.texture": "Material Theme/assets/commons/close_icon--hover.png",
       "layer1.opacity": 0,
       "layer1.inner_margin": [0,0],
     },
-  
+
       // Opened file hover
-  
+
     {
       "class": "close_button",
       "parents":
@@ -900,28 +900,28 @@
       "layer0.opacity": { "target": 1.0, "speed": 7.0, "interpolation": "smoothstep" },
       "layer0.inner_margin": [0,0],
     },
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "layer0.texture": "Material Theme/assets/commons/dirty_icon--hover.png",
       "layer0.opacity": 1.0
     },
-  
+
     {
       "class": "close_button",
       "attributes": ["hover"],
       "layer0.opacity": 0,
       "layer1.opacity": 1.0
     },
-  
-  
+
+
   /* @ SCROLLBARS
    * Scrollbars settings and behavioring
   ========================================================================= */
-  
+
     // Normal Vertical scrollbar track
-  
+
     {
       "class": "scroll_bar_control",
       "layer0.tint": [250, 250, 250],
@@ -932,9 +932,9 @@
       "layer1.inner_margin": [0, 6],
       "blur": false
     },
-  
+
       // Normal Vertical scrollbar track inside overlay panel
-  
+
     // {
     //   "class": "scroll_bar_control",
     //   "parents": [{"class": "overlay_control"}],
@@ -943,9 +943,9 @@
     //   "layer0.inner_margin": [0, 6],
     //   "blur": false
     // },
-  
+
       // Normal horizontal scrollbar track
-  
+
     {
       "class": "scroll_bar_control",
       "attributes": ["horizontal"],
@@ -957,9 +957,9 @@
       "layer1.inner_margin": [6, 0],
       "blur": false
     },
-  
+
       // Normal horizontal scrollbar track inside overlay panel
-  
+
     // {
     //   "class": "scroll_bar_control",
     //   "attributes": ["horizontal"],
@@ -969,18 +969,18 @@
     //   "layer0.inner_margin": [0, 2],
     //   "blur": false
     // },
-  
+
       // Scrollbars corner
-  
+
     {
       "class": "scroll_corner_control",
       "layer0.texture": "Material Theme/assets/lighter/normal_bar_corner.png",
       "layer0.opacity": 1.0,
       "layer0.inner_margin": [1, 1]
     },
-  
+
       // Vertical puck controller
-  
+
     {
       "class": "puck_control",
       "layer0.tint": [38, 50, 255, 0],
@@ -992,9 +992,9 @@
       "content_margin": [6, 16],
       "blur": false
     },
-  
+
       // Horizontal puck controller
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -1004,34 +1004,34 @@
       "content_margin": [16, 6],
       "blur": false
     },
-  
+
     {
       "class": "scroll_area_control",
       "settings": ["overlay_scroll_bars"],
       "overlay": true
     },
-  
+
     {
       "class": "scroll_area_control",
       "settings": ["!overlay_scroll_bars"],
       "overlay": false // set to false for the original behavior
     },
-  
-  
+
+
     {
       "class": "scroll_area_control",
       "parents": [{"class": "overlay_control"}],
       "settings": ["overlay_scroll_bars"],
       "overlay": true // set to false for the original behavior
     },
-  
+
     {
       "class": "scroll_area_control",
       "parents": [{"class": "sidebar_container"}],
       "settings": ["!overlay_scroll_bars"],
       "overlay": false // set to false for the original behavior
     },
-  
+
     {
       "class": "scroll_bar_control",
       "settings": ["overlay_scroll_bars"],
@@ -1039,7 +1039,7 @@
       "layer0.inner_margin": [0, 5],
       "blur": true
     },
-  
+
     {
       "class": "scroll_bar_control",
       "settings": ["overlay_scroll_bars"],
@@ -1052,7 +1052,7 @@
       "layer1.opacity": 0.0,
       "blur": true
     },
-  
+
     {
       "class": "puck_control",
       "layer0.tint": [250, 250, 250],
@@ -1063,7 +1063,7 @@
       "content_margin": [6, 16],
       "blur": true
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -1075,19 +1075,19 @@
       "content_margin": [16, 6],
       "blur": true
     },
-  
-  
+
+
   /* @ MINIMAP
    * Minimap settings and behavioring
   ========================================================================= */
-  
+
     {
       "class": "minimap_control",
       "settings": ["always_show_minimap_viewport"],
       "viewport_color": [128, 203, 196, 80],
       "viewport_opacity": 0.5,
     },
-  
+
     {
       "class": "minimap_control",
       "settings": ["!always_show_minimap_viewport"],
@@ -1100,14 +1100,14 @@
       "settings": ["!always_show_minimap_viewport"],
       "viewport_opacity": { "target": 0.4, "speed": 20.0, "interpolation": "smoothstep" },
     },
-  
-  
+
+
   /* @ STATUS BAR
    * Status bar settings and behavioring
   ========================================================================= */
-  
+
     // All labels
-  
+
     {
       "class": "label_control",
       "color": [176, 190, 197, 255],
@@ -1115,38 +1115,38 @@
       "shadow_offset": [0, 0],
       "font.bold": true
     },
-  
+
       // Status bar labels
-  
+
      {
         "class": "label_control",
         "parents": [{"class": "status_bar"}],
         "color": [144, 164, 174],
         "font.bold": false
     },
-  
+
       // Text field labels
-  
+
     {
       "class": "status_bar",
       "content_margin": [8, 0, 0, 0],
-  
+
       // Layer 0 base
       "layer0.tint": [250, 250, 250],
       "layer0.opacity": 1.0,
       "layer0.inner_margin": [2, 2],
-  
+
       // Visible tint layer
       "layer1.tint": [225,225,225],
       "layer1.opacity": 0.0
-  
+
     },
-  
+
     {
       "class": "status_container",
       "content_margin": [24, 12, 24, 12],
     },
-  
+
     {
       "class": "status_button",
       "layer0.tint": [250, 250, 250],
@@ -1156,7 +1156,7 @@
       "content_margin": [10, 2, 10, 3],
       "min_size": [75, 0]
     },
-  
+
     {
       "class": "status_button",
       "layer0.tint": [250, 250, 250],
@@ -1166,7 +1166,7 @@
       "content_margin": [10, 2, 10, 3],
       "min_size": [75, 0],
     },
-  
+
       // panel switcher
     {
       "class": "panel_button_control",
@@ -1174,18 +1174,18 @@
       "layer0.opacity": 1.0,
       "content_margin": [10, 10]
     },
-  
+
     {
       "class": "panel_button_control",
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/commons/overflow_menu--hover.png",
     },
-  
-  
+
+
   /* @ WIDGET PANEL
    * Widget, input, buttons settings and behavioring
   ========================================================================= */
-  
+
     // Status bar panel
     {
       "class": "panel_control",
@@ -1197,9 +1197,9 @@
       "layer1.opacity": 1.0,
       "content_margin": [6, 14, 6, 8],
     },
-  
+
       // Status bar panel close icon
-  
+
     {
       "class": "panel_close_button",
       "layer0.texture": "Material Theme/assets/lighter/close_icon.png",
@@ -1208,16 +1208,16 @@
       "layer1.opacity": 0.0,
       "content_margin": [0, 0] // 8,8 to show
     },
-  
+
     {
       "class": "panel_close_button",
       "attributes": ["hover"],
       "layer0.opacity": 0.0,
       "layer1.opacity": 1.0,
     },
-  
+
       // Texline input
-  
+
     {
       "class": "text_line_control",
       "layer0.texture": "Material Theme/assets/lighter/input_field_border.png",
@@ -1226,10 +1226,10 @@
       "tint_index": 1,
       "content_margin": [10, 8, 16, 8]
     },
-  
-  
+
+
       // Textline input inside overlay panels
-  
+
     {
       "class": "text_line_control",
       "parents": [{"class": "overlay_control"}],
@@ -1237,12 +1237,12 @@
       "layer0.opacity": 1.0,
       "layer0.inner_margin": [32, 0, 32, 2],
       "layer0.draw_center": true,
-  
+
       "content_margin": [32, 8, 32, 8]
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "content_margin": [12, 12],
@@ -1258,20 +1258,20 @@
       "attributes": ["hover"],
       "layer1.opacity": 1.0
     },
-  
+
   /* @ BUTTONS
    * Buttons panels settings and behavioring
   ========================================================================= */
-  
+
     // Button labels
-  
+
      {
         "class": "label_control",
         "parents": [{"class": "button_control"}],
         "color": [176, 190, 196],
         "font.bold": true
      },
-  
+
      {
       "class": "button_control",
       "content_margin": [6, 12, 6, 12],
@@ -1302,7 +1302,7 @@
       "attributes": ["hover"],
       "layer2.opacity": { "target": 1.0, "speed": 5.0, "interpolation": "smoothstep" }
     },
-  
+
     // Small Icon Buttons
     {
       "class": "icon_button_control",
@@ -1313,11 +1313,11 @@
       "layer2.opacity": { "target": 0.0, "speed": 10.0, "interpolation": "smoothstep" },
       "content_margin": [10, 6]
     },
-  
-  
+
+
     /* Buttons icons settings
     ===================================================================== */
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
@@ -1327,16 +1327,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_regex",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "layer0.texture": "Material Theme/assets/commons/find_case--hover.png",
@@ -1345,16 +1345,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_case",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "layer0.texture": "Material Theme/assets/commons/find_word--hover.png",
@@ -1363,17 +1363,17 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
-  
+
+
      {
         "class": "icon_whole_word",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "layer0.texture": "Material Theme/assets/commons/find_wrap--hover.png",
@@ -1382,16 +1382,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_wrap",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "layer0.texture": "Material Theme/assets/commons/find_inselection--hover.png",
@@ -1400,17 +1400,17 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12,12]
     },
-  
-  
+
+
      {
         "class": "icon_in_selection",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "layer0.texture": "Material Theme/assets/commons/find_highlight--hover.png",
@@ -1419,16 +1419,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_highlight",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "layer0.texture": "Material Theme/assets/commons/replace_preserve_case--hover.png",
@@ -1437,16 +1437,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_preserve_case",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "layer0.texture": "Material Theme/assets/commons/find_context--hover.png",
@@ -1455,17 +1455,17 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
-  
+
+
      {
         "class": "icon_context",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "layer0.texture": "Material Theme/assets/commons/use_buffer--hover.png",
@@ -1474,16 +1474,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_use_buffer",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "layer0.texture": "Material Theme/assets/commons/find_reverse--hover.png",
@@ -1492,121 +1492,121 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_reverse",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
   // Lime Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_lime"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-lime/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_lime"],
       "layer0.tint": [124, 179, 66],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_lime"],
       "layer0.tint": [124, 179, 66],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_lime"],
       "match_fg": [124, 179, 66],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_lime"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_lime", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-lime/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-lime/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_lime"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [124, 179, 66]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [124, 179, 66]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_lime"],
       "layer2.texture": "Material Theme/assets/accent-lime/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-lime/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_lime"],
@@ -1633,9 +1633,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_lime"],
@@ -1656,7 +1656,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_lime"],
@@ -1666,7 +1666,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-lime/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -1676,7 +1676,7 @@
       "layer3.texture": "Material Theme/assets/accent-lime/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1686,7 +1686,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1696,7 +1696,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1706,7 +1706,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1716,37 +1716,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-lime/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_lime"],
@@ -1754,9 +1754,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_lime"],
@@ -1765,9 +1765,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_lime"],
@@ -1775,123 +1775,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_lime"],
       "viewport_color": [124, 179, 66, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -1899,9 +1899,9 @@
       "layer1.texture": "Material Theme/assets/accent-lime/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_lime"],
@@ -1909,121 +1909,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-lime/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-lime/folder_dup--hover.png"
     },
-  
+
   // Purple Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_purple"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-purple/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_purple"],
       "layer0.tint": [171, 71, 188],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_purple"],
       "layer0.tint": [171, 71, 188],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_purple"],
       "match_fg": [171, 71, 188],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_purple"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_purple", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-purple/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-purple/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_purple"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [171, 71, 188]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_purple"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [171, 71, 188]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_purple"],
       "layer2.texture": "Material Theme/assets/accent-purple/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-purple/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_purple"],
@@ -2050,9 +2050,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_purple"],
@@ -2073,7 +2073,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_purple"],
@@ -2083,7 +2083,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-purple/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -2093,7 +2093,7 @@
       "layer3.texture": "Material Theme/assets/accent-purple/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2103,7 +2103,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2113,7 +2113,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2123,7 +2123,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2133,37 +2133,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-purple/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_purple"],
@@ -2171,9 +2171,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_purple"],
@@ -2182,9 +2182,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_purple"],
@@ -2192,123 +2192,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_purple"],
       "viewport_color": [171, 71, 188, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -2316,9 +2316,9 @@
       "layer1.texture": "Material Theme/assets/accent-purple/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_purple"],
@@ -2326,121 +2326,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-purple/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_purple"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-purple/folder_dup--hover.png"
     },
-  
+
   // Red Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_red"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-red/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_red"],
       "layer0.tint": [229, 115, 115],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_red"],
       "layer0.tint": [229, 115, 115],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_red"],
       "match_fg": [229, 115, 115],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_red"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_red", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-red/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-red/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_red"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [229, 115, 115]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_red"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [229, 115, 115]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_red"],
       "layer2.texture": "Material Theme/assets/accent-red/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-red/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_red"],
@@ -2467,9 +2467,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_red"],
@@ -2490,7 +2490,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_red"],
@@ -2500,7 +2500,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-red/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -2510,7 +2510,7 @@
       "layer3.texture": "Material Theme/assets/accent-red/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2520,7 +2520,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2530,7 +2530,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2540,7 +2540,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2550,37 +2550,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-red/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_red"],
@@ -2588,9 +2588,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_red"],
@@ -2599,9 +2599,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_red"],
@@ -2609,123 +2609,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_red"],
       "viewport_color": [229, 115, 115, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -2733,9 +2733,9 @@
       "layer1.texture": "Material Theme/assets/accent-red/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_red"],
@@ -2743,121 +2743,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-red/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_red"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-red/folder_dup--hover.png"
     },
-  
+
   // Orange Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_orange"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-orange/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_orange"],
       "layer0.tint": [255, 112, 66],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_orange"],
       "layer0.tint": [255, 112, 66],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_orange"],
       "match_fg": [255, 112, 66],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_orange"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_orange", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-orange/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-orange/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_orange"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [255, 112, 66]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_orange"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [255, 112, 66]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_orange"],
       "layer2.texture": "Material Theme/assets/accent-orange/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-orange/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_orange"],
@@ -2884,9 +2884,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_orange"],
@@ -2907,7 +2907,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_orange"],
@@ -2917,7 +2917,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-orange/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -2927,7 +2927,7 @@
       "layer3.texture": "Material Theme/assets/accent-orange/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2937,7 +2937,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2947,7 +2947,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2957,7 +2957,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2967,37 +2967,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-orange/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_orange"],
@@ -3005,9 +3005,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_orange"],
@@ -3016,9 +3016,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_orange"],
@@ -3026,123 +3026,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_orange"],
       "viewport_color": [255, 112, 66, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -3150,9 +3150,9 @@
       "layer1.texture": "Material Theme/assets/accent-orange/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_orange"],
@@ -3160,121 +3160,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-orange/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_orange"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-orange/folder_dup--hover.png"
     },
-  
+
   // Yellow Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_yellow"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-yellow/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_yellow"],
       "layer0.tint": [255, 160, 0],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_yellow"],
       "layer0.tint": [255, 160, 0],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_yellow"],
       "match_fg": [255, 160, 0],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_yellow"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_yellow", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-yellow/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-yellow/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_yellow"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [255, 160, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_yellow"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [255, 160, 0]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_yellow"],
       "layer2.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-yellow/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_yellow"],
@@ -3301,9 +3301,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_yellow"],
@@ -3324,7 +3324,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_yellow"],
@@ -3334,7 +3334,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -3344,7 +3344,7 @@
       "layer3.texture": "Material Theme/assets/accent-yellow/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3354,7 +3354,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3364,7 +3364,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3374,7 +3374,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3384,37 +3384,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-yellow/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_yellow"],
@@ -3422,9 +3422,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_yellow"],
@@ -3433,9 +3433,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_yellow"],
@@ -3443,123 +3443,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_yellow"],
       "viewport_color": [255, 160, 0, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -3567,9 +3567,9 @@
       "layer1.texture": "Material Theme/assets/accent-yellow/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_yellow"],
@@ -3577,121 +3577,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-yellow/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_yellow"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-yellow/folder_dup--hover.png"
     },
-  
+
   // Indigo Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_indigo"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-indigo/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_indigo"],
       "layer0.tint": [92, 107, 192],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_indigo"],
       "layer0.tint": [92, 107, 192],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_indigo"],
       "match_fg": [92, 107, 192],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_indigo"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_indigo", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-indigo/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-indigo/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_indigo"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [92, 107, 192]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_indigo"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [92, 107, 192]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_indigo"],
       "layer2.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-indigo/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_indigo"],
@@ -3718,9 +3718,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_indigo"],
@@ -3741,7 +3741,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_indigo"],
@@ -3751,7 +3751,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -3761,7 +3761,7 @@
       "layer3.texture": "Material Theme/assets/accent-indigo/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3771,7 +3771,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3781,7 +3781,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3791,7 +3791,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3801,37 +3801,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-indigo/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_indigo"],
@@ -3839,9 +3839,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_indigo"],
@@ -3850,9 +3850,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_indigo"],
@@ -3860,123 +3860,128 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
+    {
+      "class": "quick_panel_detail_label",
+      "link_color": "#2196F3"
+    },
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_indigo"],
       "viewport_color": [92, 107, 192, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -3984,9 +3989,9 @@
       "layer1.texture": "Material Theme/assets/accent-indigo/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_indigo"],
@@ -3994,121 +3999,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-indigo/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_indigo"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-indigo/folder_dup--hover.png"
     },
-  
+
   // Pink Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_pink"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-pink/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_pink"],
       "layer0.tint": [255, 64, 129],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_pink"],
       "layer0.tint": [255, 64, 129],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_pink"],
       "match_fg": [255, 64, 129],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_pink"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_pink", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-pink/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-pink/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_pink"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [255, 64, 129]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_pink"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [255, 64, 129]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_pink"],
       "layer2.texture": "Material Theme/assets/accent-pink/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-pink/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_pink"],
@@ -4135,9 +4140,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_pink"],
@@ -4158,7 +4163,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_pink"],
@@ -4168,7 +4173,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-pink/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -4178,7 +4183,7 @@
       "layer3.texture": "Material Theme/assets/accent-pink/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4188,7 +4193,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4198,7 +4203,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4208,7 +4213,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4218,37 +4223,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-pink/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_pink"],
@@ -4256,9 +4261,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_pink"],
@@ -4267,9 +4272,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_pink"],
@@ -4277,123 +4282,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_pink"],
       "viewport_color": [255, 64, 129, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -4401,9 +4406,9 @@
       "layer1.texture": "Material Theme/assets/accent-pink/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_pink"],
@@ -4411,121 +4416,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-pink/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_pink"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-pink/folder_dup--hover.png"
     },
-  
+
   // Blue Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_blue"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-blue/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_blue"],
       "layer0.tint": [41, 121, 255],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_blue"],
       "layer0.tint": [41, 121, 255],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_blue"],
       "match_fg": [41, 121, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_blue"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_blue", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-blue/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-blue/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_blue"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [41, 121, 255]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_blue"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [41, 121, 255]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_blue"],
       "layer2.texture": "Material Theme/assets/accent-blue/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-blue/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_blue"],
@@ -4552,9 +4557,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_blue"],
@@ -4575,7 +4580,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_blue"],
@@ -4585,7 +4590,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-blue/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -4595,7 +4600,7 @@
       "layer3.texture": "Material Theme/assets/accent-blue/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4605,7 +4610,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4615,7 +4620,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4625,7 +4630,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4635,37 +4640,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-blue/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_blue"],
@@ -4673,9 +4678,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_blue"],
@@ -4684,9 +4689,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_blue"],
@@ -4694,123 +4699,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_blue"],
       "viewport_color": [41, 121, 255, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -4818,9 +4823,9 @@
       "layer1.texture": "Material Theme/assets/accent-blue/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_blue"],
@@ -4828,121 +4833,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-blue/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_blue"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-blue/folder_dup--hover.png"
     },
-  
+
   // Cyan Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_cyan"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-cyan/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_cyan"],
       "layer0.tint": [0, 188, 212],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_cyan"],
       "layer0.tint": [0, 188, 212],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_cyan"],
       "match_fg": [0, 188, 212],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_cyan"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_cyan", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-cyan/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-cyan/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_cyan"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [0, 188, 212]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_cyan"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [0, 188, 212]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_cyan"],
       "layer2.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-cyan/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_cyan"],
@@ -4969,9 +4974,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_cyan"],
@@ -4992,7 +4997,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_cyan"],
@@ -5002,7 +5007,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -5012,7 +5017,7 @@
       "layer3.texture": "Material Theme/assets/accent-cyan/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5022,7 +5027,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5032,7 +5037,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5042,7 +5047,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5052,37 +5057,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-cyan/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_cyan"],
@@ -5090,9 +5095,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_cyan"],
@@ -5101,9 +5106,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_cyan"],
@@ -5111,123 +5116,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_cyan"],
       "viewport_color": [0, 188, 212, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -5235,9 +5240,9 @@
       "layer1.texture": "Material Theme/assets/accent-cyan/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_cyan"],
@@ -5245,121 +5250,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-cyan/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_cyan"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-cyan/folder_dup--hover.png"
     },
-  
+
   // Bright Teal Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_bright-teal"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.tint": [100, 255, 218],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.tint": [100, 255, 218],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_bright-teal"],
       "match_fg": [100, 255, 218],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_bright-teal"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_bright-teal", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-bright-teal/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_bright-teal"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [100, 255, 218]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_bright-teal"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [100, 255, 218]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_bright-teal"],
       "layer2.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-bright-teal/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5386,9 +5391,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5409,7 +5414,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5419,7 +5424,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -5429,7 +5434,7 @@
       "layer3.texture": "Material Theme/assets/accent-bright-teal/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5439,7 +5444,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5449,7 +5454,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5459,7 +5464,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5469,37 +5474,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5507,9 +5512,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5518,9 +5523,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5528,123 +5533,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_bright-teal"],
       "viewport_color": [100, 255, 218, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -5652,9 +5657,9 @@
       "layer1.texture": "Material Theme/assets/accent-bright-teal/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5662,121 +5667,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_bright-teal"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/folder_dup--hover.png"
     },
-  
+
   // Acid Lime Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_acid-lime"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.tint": [198, 255, 0],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.tint": [198, 255, 0],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_acid-lime"],
       "match_fg": [198, 255, 0],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_acid-lime"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_acid-lime", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-acid-lime/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_acid-lime"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [198, 255, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_acid-lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [198, 255, 0]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_acid-lime"],
       "layer2.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-acid-lime/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5803,9 +5808,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5826,7 +5831,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5836,7 +5841,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -5846,7 +5851,7 @@
       "layer3.texture": "Material Theme/assets/accent-acid-lime/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5856,7 +5861,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5866,7 +5871,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5876,7 +5881,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5886,37 +5891,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5924,9 +5929,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5935,9 +5940,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5945,123 +5950,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_acid-lime"],
       "viewport_color": [198, 255, 0, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -6069,9 +6074,9 @@
       "layer1.texture": "Material Theme/assets/accent-acid-lime/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_acid-lime"],
@@ -6079,121 +6084,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_acid-lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/folder_dup--hover.png"
     },
-  
+
   // Graphite Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_graphite"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-graphite/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_graphite"],
       "layer0.tint": [97, 97, 97],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_graphite"],
       "layer0.tint": [97, 97, 97],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_graphite"],
       "match_fg": [97, 97, 97],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_graphite"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_graphite", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-graphite/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-graphite/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_graphite"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [97, 97, 97]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_graphite"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [97, 97, 97]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_graphite"],
       "layer2.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-graphite/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_graphite"],
@@ -6220,9 +6225,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_graphite"],
@@ -6243,7 +6248,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_graphite"],
@@ -6253,7 +6258,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -6263,7 +6268,7 @@
       "layer3.texture": "Material Theme/assets/accent-graphite/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6273,7 +6278,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6283,7 +6288,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6293,7 +6298,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6303,37 +6308,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-graphite/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_graphite"],
@@ -6341,9 +6346,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_graphite"],
@@ -6352,9 +6357,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_graphite"],
@@ -6362,123 +6367,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_graphite"],
       "viewport_color": [97, 97, 97, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -6486,9 +6491,9 @@
       "layer1.texture": "Material Theme/assets/accent-graphite/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_graphite"],
@@ -6496,121 +6501,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-graphite/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_graphite"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-graphite/folder_dup--hover.png"
     },
-  
+
   // Breaking Bad Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_brba"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-brba/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_brba"],
       "layer0.tint": [56, 142, 60],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_brba"],
       "layer0.tint": [56, 142, 60],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_brba"],
       "match_fg": [56, 142, 60],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_brba"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_brba", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-brba/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-brba/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_brba"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [56, 142, 60]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_brba"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [56, 142, 60]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_brba"],
       "layer2.texture": "Material Theme/assets/accent-brba/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-brba/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_brba"],
@@ -6637,9 +6642,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_brba"],
@@ -6660,7 +6665,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_brba"],
@@ -6670,7 +6675,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-brba/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -6680,7 +6685,7 @@
       "layer3.texture": "Material Theme/assets/accent-brba/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6690,7 +6695,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6700,7 +6705,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6710,7 +6715,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6720,37 +6725,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-brba/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_brba"],
@@ -6758,9 +6763,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_brba"],
@@ -6769,9 +6774,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_brba"],
@@ -6779,123 +6784,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_brba"],
       "viewport_color": [56, 142, 60, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -6903,9 +6908,9 @@
       "layer1.texture": "Material Theme/assets/accent-brba/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_brba"],
@@ -6913,121 +6918,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-brba/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_brba"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-brba/folder_dup--hover.png"
     },
-  
+
   // Sky Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_sky"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-sky/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_sky"],
       "layer0.tint": [132, 255, 255],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_sky"],
       "layer0.tint": [132, 255, 255],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_sky"],
       "match_fg": [132, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_sky"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_sky", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-sky/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-sky/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_sky"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [132, 255, 255]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_sky"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [132, 255, 255]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_sky"],
       "layer2.texture": "Material Theme/assets/accent-sky/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-sky/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_sky"],
@@ -7054,9 +7059,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_sky"],
@@ -7077,7 +7082,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_sky"],
@@ -7087,7 +7092,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-sky/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -7097,7 +7102,7 @@
       "layer3.texture": "Material Theme/assets/accent-sky/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7107,7 +7112,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7117,7 +7122,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7127,7 +7132,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7137,37 +7142,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-sky/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_sky"],
@@ -7175,9 +7180,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_sky"],
@@ -7186,9 +7191,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_sky"],
@@ -7196,123 +7201,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_sky"],
       "viewport_color": [132, 255, 255, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -7320,9 +7325,9 @@
       "layer1.texture": "Material Theme/assets/accent-sky/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_sky"],
@@ -7330,121 +7335,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-sky/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_sky"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-sky/folder_dup--hover.png"
     },
-  
+
   // Tomato Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_tomato"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-tomato/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_tomato"],
       "layer0.tint": [244, 67, 54],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_tomato"],
       "layer0.tint": [244, 67, 54],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_tomato"],
       "match_fg": [244, 67, 54],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_tomato"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_tomato", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-tomato/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-tomato/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_tomato"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [244, 67, 54]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_tomato"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [244, 67, 54]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_tomato"],
       "layer2.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-tomato/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_tomato"],
@@ -7471,9 +7476,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_tomato"],
@@ -7494,7 +7499,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_tomato"],
@@ -7504,7 +7509,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -7514,7 +7519,7 @@
       "layer3.texture": "Material Theme/assets/accent-tomato/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7524,7 +7529,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7534,7 +7539,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7544,7 +7549,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7554,37 +7559,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-tomato/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_tomato"],
@@ -7592,9 +7597,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_tomato"],
@@ -7603,9 +7608,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_tomato"],
@@ -7613,123 +7618,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_tomato"],
       "viewport_color": [244, 67, 54, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -7737,9 +7742,9 @@
       "layer1.texture": "Material Theme/assets/accent-tomato/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_tomato"],
@@ -7747,47 +7752,47 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-tomato/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_tomato"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-tomato/folder_dup--hover.png"
     },
-  
-  
-  
+
+
+
   // @ THEME OPTIONS
   // Options override
   // =========================================================================
-  
+
     // Tabs size Settings
-  
+
     {
       "class": "tabset_control",
       "settings": ["material_theme_small_tab"],
       "tab_height": 36,
       "content_margin": [12, 0, 8, 0]
     },
-  
+
     {
       "class": "tabset_control",
       "settings": ["material_theme_tabs_autowidth"],
       "tab_width": 0
     },
-  
+
     {
       "class": "tabset_control",
       "settings": ["!enable_tab_scrolling"],
       "content_margin": [0, 0, 8, 0],
     },
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_small_tab"],
       "content_margin": [12, 8, 6, 4],
     },
-  
+
     // Tabs separator
     {
       "class": "tab_control",
@@ -7796,17 +7801,17 @@
       "layer3.inner_margin": [1, 1],
       "layer3.opacity": 1.0,
     },
-  
+
       // Tab Labels
-  
+
     {
       "class": "tab_label",
       "settings": ["material_theme_bold_tab"],
       "font.bold": true
     },
-  
+
       // Disable Folder animation
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation"],
@@ -7815,9 +7820,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/commons/folder--hover.png",
     },
-  
+
       // Disable Folder animation
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders"],
@@ -7826,11 +7831,11 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/commons/arrow_folder--opened.png",
     },
-  
+
       // Folder hover no animation
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_lime"],
@@ -7839,7 +7844,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-lime/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -7848,9 +7853,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-lime/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_purple"],
@@ -7859,7 +7864,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-purple/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -7868,9 +7873,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-purple/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_red"],
@@ -7879,7 +7884,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-red/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_red"],
@@ -7888,9 +7893,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-red/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_orange"],
@@ -7899,7 +7904,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-orange/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -7908,9 +7913,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-orange/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_yellow"],
@@ -7919,7 +7924,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -7928,9 +7933,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-yellow/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_indigo"],
@@ -7939,7 +7944,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -7948,9 +7953,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-indigo/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_pink"],
@@ -7959,7 +7964,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-pink/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -7968,9 +7973,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-pink/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_blue"],
@@ -7979,7 +7984,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-blue/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -7988,9 +7993,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-blue/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_cyan"],
@@ -7999,7 +8004,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -8008,9 +8013,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-cyan/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_bright-teal"],
@@ -8019,7 +8024,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -8028,9 +8033,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-bright-teal/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_acid-lime"],
@@ -8039,7 +8044,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -8048,9 +8053,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-acid-lime/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_graphite"],
@@ -8059,7 +8064,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -8068,9 +8073,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-graphite/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_brba"],
@@ -8079,7 +8084,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-brba/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -8088,9 +8093,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-brba/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_sky"],
@@ -8099,7 +8104,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-sky/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -8108,9 +8113,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-sky/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_tomato"],
@@ -8119,7 +8124,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -8128,26 +8133,26 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-tomato/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
       // Small status bar
-  
+
     {
       "class": "status_container",
       "settings": ["material_theme_small_statusbar"],
       "content_margin": [12, 6, 12, 6],
     },
-  
+
       // Tree Indicator
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_disable_tree_indicator"],
       "attributes": ["selected"],
       "layer1.opacity": 0.0
     },
-  
+
     // Status bar panel
     {
       "class": "panel_control",
@@ -8156,74 +8161,74 @@
       "layer1.opacity": 0.2,
       "layer1.inner_margin": [2, 2, 2, 2],
     },
-  
+
       // Contrast mode
-  
+
     {
       "class": "sidebar_container",
       "settings": ["material_theme_contrast_mode"],
       "layer1.opacity": 0.2
     },
-  
+
     {
       "class": "sidebar_tree",
       "settings": ["material_theme_contrast_mode"],
       "layer1.opacity": 0.2
     },
-  
+
     {
       "class": "status_bar",
       "settings": ["material_theme_contrast_mode"],
       "layer1.opacity": 0.2
     },
-  
+
       // Compact mode
-  
+
     {
       "class": "sidebar_tree",
       "settings": ["material_theme_compact_sidebar"],
       "row_padding": [24, 5]
     },
-  
+
     {
       "class": "panel_control",
       "settings": ["material_theme_compact_panel"],
       "content_margin": [0, 0, 0, 0],
     },
-  
+
       // Filetype icons in sidebar
-  
+
     {
       "class": "icon_file_type",
       "settings": ["material_theme_disable_fileicons"],
       "layer0.opacity": 0,
       "content_margin": [0, 0]
     },
-  
+
       // Bigger file_type icons
-  
+
     {
       "class": "icon_file_type",
       "settings": ["material_theme_big_fileicons"],
       "content_margin": [11, 11]
     },
-  
+
     {
       "class": "icon_file_type",
       "settings": ["material_theme_big_fileicons"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "content_margin": [11, 11]
     },
-  
+
         // Bright scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_bright_scrollbars"],
       "layer1.texture": "Material Theme/assets/commons/thumb_vertical.png",
       "layer1.opacity": 0.2
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -8231,9 +8236,9 @@
       "layer1.texture": "Material Theme/assets/commons/thumb_horizontal.png",
       "layer1.opacity": 0.2
     },
-  
+
       // Title bar (OS X 10.10+)
-  
+
     {
       "class": "title_bar",
       "settings": ["material_theme_titlebar"],
@@ -8241,214 +8246,214 @@
       "fg": [167, 173, 176],
       "bg": [250, 250, 250]
     },
-  
+
     {
       "class": "title_bar",
       "settings": ["material_theme_titlebar", "material_theme_contrast_mode"],
       "platforms": ["osx"],
       "fg": [167, 173, 176],
       "bg":
-        
+
           [245, 245, 245]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_lime", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [124, 179, 66],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_purple", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [171, 71, 188],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_red", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [229, 115, 115],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_orange", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [255, 112, 66],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_yellow", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [255, 160, 0],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_indigo", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [92, 107, 192],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_pink", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [255, 64, 129],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_blue", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [41, 121, 255],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_cyan", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [0, 188, 212],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_bright-teal", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [100, 255, 218],
       "fg":
-        
+
           [0, 0, 0]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_acid-lime", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [198, 255, 0],
       "fg":
-        
+
           [0, 0, 0]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_graphite", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [97, 97, 97],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_brba", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [56, 142, 60],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_sky", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [132, 255, 255],
       "fg":
-        
+
           [0, 0, 0]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_tomato", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [244, 67, 54],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
   //
 ]

--- a/Material-Theme-Palenight.sublime-theme
+++ b/Material-Theme-Palenight.sublime-theme
@@ -5,58 +5,58 @@
 
 [
   //
-  
+
   // @EMPTY WINDOW
   // Style for empty (no tabs) window
   // =========================================================================
-  
+
     {
       "class": "sheet_container_control",
       "layer0.tint": [41, 45, 62],
       "layer0.opacity": 1.0
     },
-  
+
   // @GRID LAYOUT
   // Grid style
   // =========================================================================
-  
+
     {
       "class": "grid_layout_control",
       "border_size": 1,
       "border_color": [32, 34, 48]
     },
-  
-  
-  
+
+
+
   // @ DIALOG POPUP
   // Dialog popup style and progressbar
   // =========================================================================
-  
+
     {
       "class": "progress_gauge_control",
       "layer0.tint": [128, 203, 196],
       "layer0.opacity": 1.0,
       "content_margin": [0, 6]
     },
-  
+
     {
       "class": "dialog",
       "layer0.tint": [41, 45, 62],
       "layer0.opacity": 1.0
     },
-  
+
     {
       "class": "progress_bar_control",
       "layer0.tint": [41, 45, 62],
       "layer0.opacity": 1.0,
     },
-  
-  
-  
+
+
+
   // @ CODE FOLDING
   // Folding arrow setting and behavioring
   // =========================================================================
-  
+
     {
       "class": "fold_button_control",
       "layer0.texture": "Material Theme/assets/palenight/fold_right.png",
@@ -67,41 +67,41 @@
       "layer1.inner_margin": 0,
       "content_margin": [9, 7, 8, 6]
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["hover"],
       "layer0.opacity": 0.0,
       "layer1.opacity": 1.0
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "layer0.texture": "Material Theme/assets/palenight/fold_down.png",
       "layer1.texture": "Material Theme/assets/commons/fold_down--hover.png"
     },
-  
-  
+
+
   // @ AUTOCOMPLETE
   //  Autocomplete popup setting and behavioring
   // =========================================================================
-  
-  
+
+
     {
       "class": "popup_control",
       "layer0.tint": [41, 45, 62, 255],
       "layer0.opacity": 1.0,
       "content_margin": [0, 0]
     },
-  
+
     {
       "class": "auto_complete",
       "row_padding": [12, 6],
       "layer0.tint": [41, 45, 62, 255],
       "layer0.opacity": 1.0
     },
-  
+
     {
       "class": "auto_complete_label",
       "fg": [176, 190, 197, 255],
@@ -109,24 +109,24 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
     {
       "class": "table_row",
       "layer0.tint": [103, 110, 149],
       "layer0.opacity": 0.0,
     },
-  
+
     {
       "class": "table_row",
       "attributes": ["selected"],
       "layer0.opacity": 0.3
     },
-  
-  
+
+
   /* @ TOOLTIP
    * Tooltip setting and behavioring
   ========================================================================= */
-  
+
     {
       "class": "tool_tip_control",
       "layer0.tint": [128, 203, 196],
@@ -134,17 +134,17 @@
       "layer0.opacity": 1.0,
       "content_margin": [16, 8]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "color": [0, 0, 0, 150]
     },
-  
-  
+
+
   /* @OVERLAY PANELS
    * Overlay panels setting and behavioring
   ========================================================================= */
-  
+
     // Command Panel
      {
         "class": "overlay_control",
@@ -156,53 +156,53 @@
         "layer1.opacity": 1.0,
         "content_margin": [13, 13, 13, 33]
      },
-  
+
       // Command Panel list item style (cmd + shift + p)
-  
+
     {
       "class": "mini_quick_panel_row",
       "layer0.tint": [41, 45, 62, 0],
       "layer0.inner_margin": [2, 2, 2, 2],
       "layer0.opacity": 1.0
     },
-  
+
       // Command Panel selected list item style (cmd + p)
-  
+
     {
       "class": "mini_quick_panel_row",
       "attributes": ["selected"],
       "layer0.tint": [103, 110, 149],
       "layer0.opacity": 0.3
     },
-  
+
       // Quick panel project setting (project manager) (cmd + ctrl + p)
-  
+
     {
       "class": "quick_panel",
       "row_padding": [32, 12],
       "layer0.tint": [41, 45, 62],
       "layer0.opacity": 1.0
     },
-  
+
       // Quick Panel row default style (project manager)
-  
+
     {
       "class": "quick_panel_row",
       "layer0.tint": [41, 45, 62, 0],
       "layer0.opacity": 1.0
     },
-  
+
       // Row panel style inside command panel (cmd + shift + p)
-  
+
     {
       "class": "quick_panel_row",
       "parents": [{"class": "overlay_control"}],
       "layer0.tint": [41, 45, 62, 0],
       "layer0.opacity": 1.0
     },
-  
+
       // Quick panel (project) style inside overlay_control (cmd + shift + p)
-  
+
     {
       "class": "quick_panel",
       "parents": [{"class": "overlay_control"}],
@@ -210,9 +210,9 @@
       "layer0.tint": [41, 45, 62, 0],
       "layer0.opacity": 1.0
     },
-  
+
       // Quick Panel selected list item style
-  
+
     {
       "class": "quick_panel_row",
       "attributes": ["selected"],
@@ -220,9 +220,9 @@
       "layer0.opacity": 0.3,
       "layer1.opacity": 0.0
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "fg": [176, 190, 197, 255],
@@ -230,9 +230,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "parents": [{"class": "overlay_control"}],
@@ -241,9 +241,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "fg": [103, 110, 149, 255],
@@ -251,20 +251,20 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "quick_panel_score_label",
       "fg": [166, 172, 205, 255],
       "selected_fg": [255, 255, 255, 255]
     },
-  
-  
+
+
   /* @ TABS
    * Tabs settings and behavioring
   ========================================================================= */
-  
+
     {
       "class": "tabset_control",
       "attributes": ["file_medium_dark"],
@@ -280,31 +280,31 @@
       "tab_height": 54,
       "mouse_wheel_switch": false
     },
-  
+
     {
       "class": "tabset_control",
       "settings": ["mouse_wheel_switches_tabs", "!enable_tab_scrolling"],
       "mouse_wheel_switch": true
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
-  
+
       "layer0.tint": [41, 45, 62],
       "layer0.inner_margin": [24, 0],
       "layer0.opacity": 1.0,
       "tint_index": 0,
-  
+
       "layer1.texture": "Material Theme/assets/palenight/tab_current.png",
       "layer1.inner_margin": [0, 0],
       "layer1.opacity": 0.0,
-  
+
       "layer2.tint": [128, 203, 196, 0],
       "layer2.inner_margin": [0, 0],
       "layer2.opacity": { "target": 0.0, "speed": 3.0, "interpolation": "smoothstep" },
-  
+
       "layer3.inner_margin": [0, 0],
       "layer3.opacity": { "target": 1.0, "speed": 2.0, "interpolation": "smoothstep" },
       "layer3.texture": {
@@ -327,41 +327,41 @@
               "loop": false,
               "frame_time": 0.015,
       },
-  
+
       "content_margin": [16, 0, 8, 0],
       "max_margin_trim": 0,
       "hit_test_level": 0.4
     },
-  
+
       // Selected current tab
-  
+
     {
       "class": "tab_control", "attributes": ["selected"],
       "layer1.opacity": 1.0,
       "layer2.opacity": 0.0,
       "layer3.opacity": 0.0
     },
-  
+
       // Hovered current tab
-  
+
     {
       "class": "tab_control", "attributes": ["hover"],
       "layer1.opacity": 1.0,
       "layer2.opacity": { "target": 0.6, "speed": 5.0, "interpolation": "smoothstep" },
       "layer3.opacity": { "target": 0.0, "speed": 2.0, "interpolation": "smoothstep" }
     },
-  
+
       // Selected current tab
-  
+
     {
       "class": "tab_control", "attributes": ["selected","hover"],
       "layer1.opacity": 1.0,
       "layer2.opacity": { "target": 0.6, "speed": 5.0, "interpolation": "smoothstep" },
       "layer3.opacity": 0.0
     },
-  
+
       // Tab Labels
-  
+
     {
       "class": "tab_label",
       "fg": [103, 110, 149, 255],
@@ -371,9 +371,9 @@
       "font.italic": false,
       "font.bold": false
     },
-  
+
       // Tab selected label color
-  
+
     {
       "class": "tab_label",
       "parents": [{"class": "tab_control", "attributes": ["selected"]}],
@@ -381,36 +381,36 @@
       "shadow_color": [255, 255, 255, 0],
       "shadow_offset": [0, 0]
     },
-  
+
     {
       "class": "tab_label",
       "attributes": ["transient"],
       "font.italic": true
     },
-  
+
       // Tab Close Buttons
     {
       "class": "tab_close_button",
       "content_margin": [0, 0],
-  
+
        // Close Icon
       "layer0.texture": "Material Theme/assets/palenight/close_icon.png",
       "layer0.opacity": 1,
       "layer0.inner_margin": 0,
-  
+
       // Close Icon Hover
       "layer1.texture": "Material Theme/assets/commons/close_icon--hover.png",
       "layer1.opacity": { "target": 0.0, "speed": 5.0, "interpolation": "smoothstep" },
-  
+
        // Dirty Icon
       "layer2.texture": "Material Theme/assets/palenight/dirty_icon.png",
       "layer2.inner_margin": 0,
-  
+
       // Dirty Icon Hover
       "layer3.texture": "Material Theme/assets/commons/dirty_icon--hover.png",
       "layer3.opacity": { "target": 0.0, "speed": 5.0, "interpolation": "smoothstep" }
     },
-  
+
       // Default
     {
       "class": "tab_close_button",
@@ -443,7 +443,7 @@
       "layer3.opacity": 1, // Dirty Icon Hover
       "content_margin": [8,8],
     },
-  
+
       // Dirty tab on hover
     {
       "class": "tab_close_button",
@@ -484,13 +484,13 @@
       "layer1.opacity": { "target": 0.0, "speed": 8.0, "interpolation": "smoothstep" },
       "layer1.inner_margin": 0,
     },
-  
+
     {
       "class": "scroll_tabs_left_button",
       "attributes": ["hover"],
       "layer1.opacity": { "target": 1.0, "speed": 8.0, "interpolation": "smoothstep" }
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "content_margin": [14, 7],
@@ -501,13 +501,13 @@
       "layer1.opacity": { "target": 0.0, "speed": 8.0, "interpolation": "smoothstep" },
       "layer1.inner_margin": 0,
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "attributes": ["hover"],
       "layer1.opacity": { "target": 1.0, "speed": 8.0, "interpolation": "smoothstep" }
     },
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "content_margin": [12, 12],
@@ -518,19 +518,19 @@
       "layer1.opacity": { "target": 0.0, "speed": 8.0, "interpolation": "smoothstep" },
       "layer1.inner_margin": 0,
     },
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "attributes": ["hover"],
       "layer1.opacity": { "target": 1.0, "speed": 8.0, "interpolation": "smoothstep" }
     },
-  
-  
+
+
   /* @ SIDEBAR
    * Sidebar panel settings and behavioring
   ========================================================================= */
-  
-  
+
+
     {
       "class": "sidebar_container",
       "content_margin": [0, 12, 0, 0],
@@ -552,7 +552,7 @@
       "layer1.tint": [0,0,0],
       "layer1.opacity": 0.0
     },
-  
+
     {
       "class": "sidebar_heading",
       "color": [207, 216, 220],
@@ -561,7 +561,7 @@
       "shadow_color": [250, 250, 250, 0],
       "shadow_offset": [0, 0],
     },
-  
+
     {
       "class": "sidebar_heading",
       "parents":
@@ -570,22 +570,22 @@
       ],
       "shadow_color": [160, 174, 192, 0],
     },
-  
+
     {
        "class": "tree_row",
        "layer1.texture": "Material Theme/assets/commons/tree_highlight.png",
        "layer1.opacity": { "target": 0.0, "speed": 5.0, "interpolation": "smoothstep" },
        "layer1.inner_margin": [22, 8, 0, 0]
     },
-  
+
     {
        "class": "tree_row",
        "attributes": ["selected"],
        "layer1.opacity": { "target": 1.0, "speed": 5.0, "interpolation": "smoothstep" }
     },
-  
+
       // Bullet Tree Indicator
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_bullet_tree_indicator"],
@@ -593,7 +593,7 @@
       "layer1.texture": "Material Theme/assets/commons/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "color": [103, 110, 149],
@@ -602,7 +602,7 @@
       "shadow_color": [255, 255, 255, 0],
       "shadow_offset": [0, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["hover"]}],
@@ -610,81 +610,81 @@
       "shadow_color": [255, 255, 255, 0],
       "shadow_offset": [0, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "font.bold": false,
       "color": [128, 203, 196]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expandable"]}],
       "color": [166, 172, 205]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expandable"]}],
       "settings": ["bold_folder_labels"],
       "font.bold": true
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expandable", "selected"]}],
       "color": [255, 255, 255]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [128, 203, 196]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "settings": ["bold_folder_labels"],
       "font.bold": true
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expanded", "selected"]}],
       "color": [255, 255, 255]
     },
-  
+
     {
       "class": "sidebar_label",
       "attributes": ["transient"],
       "font.italic": false
     },
-  
+
       // File icons and folder
-  
+
     {
       "class": "icon_file_type",
       // layer0.texture is filled in by code with the relevant icon name
       "layer0.opacity": 0.6,
       "content_margin": [9, 9]
     },
-  
+
     {
       "class": "icon_file_type",
       "parents": [{"class": "tree_row", "attributes": ["hover"]}],
       "layer0.opacity": { "target": 1.0, "speed": 3.0, "interpolation": "smoothstep" }
     },
-  
+
     {
       "class": "icon_file_type",
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "layer0.opacity": 1.0
     },
-  
+
       // Secondary folder icon (original) used as main folder icon
-  
+
     {
       "class": "icon_folder",
       "content_margin": [11, 7],
@@ -697,7 +697,7 @@
       "layer3.texture": "Material Theme/assets/commons/folder_opened--hover.png",
       "layer3.opacity": 0.0,
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -710,7 +710,7 @@
       "layer3.texture": "Material Theme/assets/commons/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "parents":
@@ -721,7 +721,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0,
     },
-  
+
     {
       "class": "icon_folder",
       "parents":
@@ -732,7 +732,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0,
     },
-  
+
     {
       "class": "icon_folder",
       "parents":
@@ -742,7 +742,7 @@
       "layer1.texture": "Material Theme/assets/commons/folder--hover.png",
       "layer1.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "parents":
@@ -774,8 +774,8 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0,
     },
-  
-  
+
+
       // Arrow icon folder Expandend - Hover
     {
       "class": "icon_folder",
@@ -783,9 +783,9 @@
       "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
       "layer3.texture": "Material Theme/assets/commons/arrow_folder--opened.png",
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "layer0.texture":
@@ -808,35 +808,35 @@
         "loop": true,
         "frame_time": 0.075,
       },
-  
+
       "layer0.opacity": 1.0,
       "content_margin": [8, 8]
     },
-  
+
       // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "layer0.texture": "Material Theme/assets/palenight/folder_dup.png",
       "layer0.opacity": 1.0,
       "content_margin": [11, 7]
     },
-  
+
     {
       "class": "icon_folder_dup",
       "parents":
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/commons/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/commons/folder_dup--hover.png"
     },
-  
+
       // Hidden arrow icon before folder
-  
+
     {
       "class": "disclosure_button_control",
       "layer0.texture": "Material Theme/assets/palenight/folder.png",
@@ -847,7 +847,7 @@
       "layer1.inner_margin": 0,
       "content_margin": [0, 0, 0, 0]
     },
-  
+
     {
       "class": "disclosure_button_control",
       "parents":
@@ -857,45 +857,45 @@
       "layer0.opacity": 0.0,
       "layer1.opacity": 1.0
     },
-  
+
     {
       "class": "disclosure_button_control",
       "attributes": ["expanded"],
       "layer0.texture": "Material Theme/assets/commons/folder_opened--hover.png",
     },
-  
+
     {
       "class": "tree_row",
       "layer0.tint": [41, 45, 62],
       "layer0.opacity": 0.0,
       "layer0.inner_margin": [1, 1]
     },
-  
+
     {
       "class": "tree_row",
       "attributes": ["selected"],
       "layer0.opacity": 1
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "content_margin": [8, 8],
-  
+
       // Default Close icon
       "layer0.texture": "Material Theme/assets/palenight/close_icon.png",
       "layer0.opacity": { "target": 0.0, "speed": 7.0, "interpolation": "smoothstep" },
       "layer0.inner_margin": [0,0],
-  
+
       // Hover close icon
       "layer1.texture": "Material Theme/assets/commons/close_icon--hover.png",
       "layer1.opacity": 0,
       "layer1.inner_margin": [0,0],
     },
-  
+
       // Opened file hover
-  
+
     {
       "class": "close_button",
       "parents":
@@ -907,28 +907,28 @@
       "layer0.opacity": { "target": 1.0, "speed": 7.0, "interpolation": "smoothstep" },
       "layer0.inner_margin": [0,0],
     },
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "layer0.texture": "Material Theme/assets/commons/dirty_icon--hover.png",
       "layer0.opacity": 1.0
     },
-  
+
     {
       "class": "close_button",
       "attributes": ["hover"],
       "layer0.opacity": 0,
       "layer1.opacity": 1.0
     },
-  
-  
+
+
   /* @ SCROLLBARS
    * Scrollbars settings and behavioring
   ========================================================================= */
-  
+
     // Normal Vertical scrollbar track
-  
+
     {
       "class": "scroll_bar_control",
       "layer0.tint": [41, 45, 62],
@@ -939,9 +939,9 @@
       "layer1.inner_margin": [0, 6],
       "blur": false
     },
-  
+
     //   // Normal Vertical scrollbar track inside overlay panel
-  
+
     // {
     //   "class": "scroll_bar_control",
     //   "parents": [{"class": "overlay_control"}],
@@ -950,9 +950,9 @@
     //   "layer0.inner_margin": [0, 6],
     //   "blur": false
     // },
-  
+
       // Normal horizontal scrollbar track
-  
+
     {
       "class": "scroll_bar_control",
       "attributes": ["horizontal"],
@@ -964,9 +964,9 @@
       "layer1.inner_margin": [6, 0],
       "blur": false
     },
-  
+
       // Normal horizontal scrollbar track inside overlay panel
-  
+
     // {
     //     "class": "scroll_bar_control",
     //     "attributes": ["horizontal"],
@@ -976,18 +976,18 @@
     //     "layer0.inner_margin": [0, 2],
     //     "blur": false
     //  },
-  
+
       // Scrollbars corner
-  
+
     {
       "class": "scroll_corner_control",
       "layer0.texture": "Material Theme/assets/palenight/normal_bar_corner.png",
       "layer0.opacity": 1.0,
       "layer0.inner_margin": [1, 1]
     },
-  
+
       // Vertical puck controller
-  
+
     {
       "class": "puck_control",
       "layer0.tint": [41, 45, 62],
@@ -999,9 +999,9 @@
       "content_margin": [6, 16],
       "blur": false
     },
-  
+
       // Horizontal puck controller
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -1014,41 +1014,41 @@
       "content_margin": [16, 6],
       "blur": false
     },
-  
+
     {
       "class": "scroll_area_control",
       "settings": ["overlay_scroll_bars"],
       "overlay": true
     },
-  
+
     {
       "class": "scroll_area_control",
       "settings": ["!overlay_scroll_bars"],
       "overlay": false // set to false for the original behavior
     },
-  
-  
+
+
     {
       "class": "scroll_area_control",
       "parents": [{"class": "overlay_control"}],
       "settings": ["overlay_scroll_bars"],
       "overlay": true // set to false for the original behavior
     },
-  
+
     {
       "class": "scroll_area_control",
       "parents": [{"class": "sidebar_container"}],
       "settings": ["!overlay_scroll_bars"],
       "overlay": false // set to false for the original behavior
     },
-  
+
     {
       "class": "scroll_bar_control",
       "settings": ["overlay_scroll_bars"],
       "layer0.texture": "Material Theme/assets/palenight/normal_bar_vertical.png",
       "layer0.inner_margin": [0, 6]
     },
-  
+
     {
       "class": "scroll_bar_control",
       "settings": ["overlay_scroll_bars"],
@@ -1061,7 +1061,7 @@
       "layer1.opacity": 0.0,
       "blur": true
     },
-  
+
     {
       "class": "puck_control",
       "layer0.tint": [41, 45, 62],
@@ -1072,7 +1072,7 @@
       "content_margin": [6, 16],
       "blur": true
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -1084,20 +1084,20 @@
       "content_margin": [16, 6],
       "blur": true
     },
-  
-  
+
+
   // @ MINIMAP
   // Minimap settings and behavioring
   // =========================================================================
-  
-  
+
+
     {
       "class": "minimap_control",
       "settings": ["always_show_minimap_viewport"],
       "viewport_color": [128, 203, 196, 80],
       "viewport_opacity": 0.5,
     },
-  
+
     {
       "class": "minimap_control",
       "settings": ["!always_show_minimap_viewport"],
@@ -1110,15 +1110,15 @@
       "settings": ["!always_show_minimap_viewport"],
       "viewport_opacity": { "target": 0.4, "speed": 20.0, "interpolation": "smoothstep" },
     },
-  
-  
-  
+
+
+
   /* @ STATUS BAR
    * Status bar settings and behavioring
   ========================================================================= */
-  
+
     // All labels
-  
+
     {
       "class": "label_control",
       "color": [103, 110, 149],
@@ -1126,35 +1126,35 @@
       "shadow_offset": [0, 0],
       "font.bold": true
     },
-  
+
     {
         "class": "label_control",
         "parents": [{"class": "status_bar"}],
         "color": [103, 110, 149],
         "font.bold": false
     },
-  
+
       // Text field labels
-  
+
     {
       "class": "status_bar",
       "content_margin": [8, 0, 0, 0],
-  
+
       // Layer 0 base
       "layer0.tint": [41, 45, 62],
       "layer0.opacity": 1.0,
       "layer0.inner_margin": [2, 2],
-  
+
       // Visible tint layer
       "layer1.tint": [0,0,0],
       "layer1.opacity": 0.0,
     },
-  
+
     {
       "class": "status_container",
       "content_margin": [24, 12, 24, 12],
     },
-  
+
     {
       "class": "status_button",
       "layer0.tint": [41, 45, 62],
@@ -1164,7 +1164,7 @@
       "content_margin": [10, 2, 10, 3],
       "min_size": [75, 0]
     },
-  
+
     {
       "class": "status_button",
       "layer0.tint": [41, 45, 62],
@@ -1174,7 +1174,7 @@
       "content_margin": [10, 2, 10, 3],
       "min_size": [75, 0],
     },
-  
+
     // panel switcher
     {
       "class": "panel_button_control",
@@ -1182,19 +1182,19 @@
       "layer0.opacity": 1.0,
       "content_margin": [10, 10]
     },
-  
+
     {
       "class": "panel_button_control",
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/commons/overflow_menu--hover.png",
     },
-  
-  
+
+
   /* @ WIDGET PANEL
    * Widget, input, buttons settings and behavioring
   ========================================================================= */
-  
-  
+
+
     // Status bar panel
     {
       "class": "panel_control",
@@ -1206,9 +1206,9 @@
       "layer1.opacity": 1.0,
       "content_margin": [6, 14, 6, 8],
     },
-  
+
       // Status bar panel close icon
-  
+
     {
       "class": "panel_close_button",
       "layer0.texture": "Material Theme/assets/palenight/close_icon.png",
@@ -1217,16 +1217,16 @@
       "layer1.opacity": 0.0,
       "content_margin": [0, 0] // 8,8 to show
     },
-  
+
     {
       "class": "panel_close_button",
       "attributes": ["hover"],
       "layer0.opacity": 0.0,
       "layer1.opacity": 1.0,
     },
-  
+
       // Texline input
-  
+
     {
       "class": "text_line_control",
       "layer0.texture": "Material Theme/assets/palenight/input_field_border.png",
@@ -1235,10 +1235,10 @@
       "tint_index": 1,
       "content_margin": [10, 8, 16, 8]
     },
-  
-  
+
+
       // Textline input inside overlay panels
-  
+
     {
       "class": "text_line_control",
       "parents": [{"class": "overlay_control"}],
@@ -1246,12 +1246,12 @@
       "layer0.opacity": 1.0,
       "layer0.inner_margin": [32, 0, 32, 2],
       "layer0.draw_center": true,
-  
+
       "content_margin": [32, 8, 32, 8]
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "content_margin": [12, 12],
@@ -1267,28 +1267,28 @@
       "attributes": ["hover"],
       "layer1.opacity": 1.0
     },
-  
-  
+
+
   // @ BUTTONS
   // Buttons panels settings and behavioring
   // =========================================================================
-  
-  
+
+
     // Button labels
-  
+
      {
         "class": "label_control",
         "parents": [{"class": "button_control"}],
         "color": [103, 110, 149],
         "font.bold": true
      },
-  
+
      {
         "class": "label_control",
         "parents": [{"class": "button_control", "attributes": ["hover"]}],
         "color": [255,255,255]
      },
-  
+
      {
       "class": "button_control",
       "content_margin": [6, 12, 6, 12],
@@ -1319,7 +1319,7 @@
       "attributes": ["hover"],
       "layer2.opacity": { "target": 1.0, "speed": 5.0, "interpolation": "smoothstep" }
     },
-  
+
     // Small Icon Buttons
     {
       "class": "icon_button_control",
@@ -1330,11 +1330,11 @@
       "layer2.opacity": { "target": 0.0, "speed": 10.0, "interpolation": "smoothstep" },
       "content_margin": [10, 6]
     },
-  
-  
+
+
     /* Buttons icons settings
     ===================================================================== */
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
@@ -1344,16 +1344,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_regex",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "layer0.texture": "Material Theme/assets/commons/find_case--hover.png",
@@ -1362,16 +1362,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_case",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "layer0.texture": "Material Theme/assets/commons/find_word--hover.png",
@@ -1380,17 +1380,17 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
-  
+
+
      {
         "class": "icon_whole_word",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "layer0.texture": "Material Theme/assets/commons/find_wrap--hover.png",
@@ -1399,16 +1399,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_wrap",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "layer0.texture": "Material Theme/assets/commons/find_inselection--hover.png",
@@ -1417,17 +1417,17 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12,12]
     },
-  
-  
+
+
      {
         "class": "icon_in_selection",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "layer0.texture": "Material Theme/assets/commons/find_highlight--hover.png",
@@ -1436,16 +1436,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_highlight",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "layer0.texture": "Material Theme/assets/commons/replace_preserve_case--hover.png",
@@ -1454,16 +1454,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_preserve_case",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "layer0.texture": "Material Theme/assets/commons/find_context--hover.png",
@@ -1472,17 +1472,17 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
-  
+
+
      {
         "class": "icon_context",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "layer0.texture": "Material Theme/assets/commons/use_buffer--hover.png",
@@ -1491,16 +1491,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_use_buffer",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "layer0.texture": "Material Theme/assets/commons/find_reverse--hover.png",
@@ -1509,122 +1509,122 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
     {
       "class": "icon_reverse",
       "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
       "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
     },
-  
-  
+
+
   // Lime Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_lime"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-lime/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_lime"],
       "layer0.tint": [124, 179, 66],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_lime"],
       "layer0.tint": [124, 179, 66],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_lime"],
       "match_fg": [124, 179, 66],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_lime"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_lime", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-lime/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-lime/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_lime"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [124, 179, 66]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [124, 179, 66]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_lime"],
       "layer2.texture": "Material Theme/assets/accent-lime/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-lime/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_lime"],
@@ -1651,9 +1651,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_lime"],
@@ -1674,7 +1674,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_lime"],
@@ -1684,7 +1684,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-lime/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -1694,7 +1694,7 @@
       "layer3.texture": "Material Theme/assets/accent-lime/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1704,7 +1704,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1714,7 +1714,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1724,7 +1724,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1734,37 +1734,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-lime/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_lime"],
@@ -1772,9 +1772,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_lime"],
@@ -1783,9 +1783,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_lime"],
@@ -1793,123 +1793,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_lime"],
       "viewport_color": [124, 179, 66, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -1917,9 +1917,9 @@
       "layer1.texture": "Material Theme/assets/accent-lime/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_lime"],
@@ -1927,121 +1927,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-lime/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-lime/folder_dup--hover.png"
     },
-  
+
   // Purple Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_purple"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-purple/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_purple"],
       "layer0.tint": [171, 71, 188],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_purple"],
       "layer0.tint": [171, 71, 188],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_purple"],
       "match_fg": [171, 71, 188],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_purple"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_purple", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-purple/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-purple/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_purple"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [171, 71, 188]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_purple"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [171, 71, 188]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_purple"],
       "layer2.texture": "Material Theme/assets/accent-purple/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-purple/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_purple"],
@@ -2068,9 +2068,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_purple"],
@@ -2091,7 +2091,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_purple"],
@@ -2101,7 +2101,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-purple/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -2111,7 +2111,7 @@
       "layer3.texture": "Material Theme/assets/accent-purple/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2121,7 +2121,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2131,7 +2131,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2141,7 +2141,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2151,37 +2151,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-purple/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_purple"],
@@ -2189,9 +2189,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_purple"],
@@ -2200,9 +2200,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_purple"],
@@ -2210,123 +2210,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_purple"],
       "viewport_color": [171, 71, 188, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -2334,9 +2334,9 @@
       "layer1.texture": "Material Theme/assets/accent-purple/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_purple"],
@@ -2344,121 +2344,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-purple/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_purple"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-purple/folder_dup--hover.png"
     },
-  
+
   // Red Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_red"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-red/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_red"],
       "layer0.tint": [229, 115, 115],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_red"],
       "layer0.tint": [229, 115, 115],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_red"],
       "match_fg": [229, 115, 115],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_red"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_red", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-red/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-red/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_red"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [229, 115, 115]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_red"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [229, 115, 115]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_red"],
       "layer2.texture": "Material Theme/assets/accent-red/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-red/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_red"],
@@ -2485,9 +2485,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_red"],
@@ -2508,7 +2508,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_red"],
@@ -2518,7 +2518,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-red/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -2528,7 +2528,7 @@
       "layer3.texture": "Material Theme/assets/accent-red/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2538,7 +2538,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2548,7 +2548,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2558,7 +2558,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2568,37 +2568,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-red/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_red"],
@@ -2606,9 +2606,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_red"],
@@ -2617,9 +2617,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_red"],
@@ -2627,123 +2627,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_red"],
       "viewport_color": [229, 115, 115, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -2751,9 +2751,9 @@
       "layer1.texture": "Material Theme/assets/accent-red/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_red"],
@@ -2761,121 +2761,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-red/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_red"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-red/folder_dup--hover.png"
     },
-  
+
   // Orange Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_orange"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-orange/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_orange"],
       "layer0.tint": [255, 112, 66],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_orange"],
       "layer0.tint": [255, 112, 66],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_orange"],
       "match_fg": [255, 112, 66],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_orange"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_orange", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-orange/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-orange/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_orange"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [255, 112, 66]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_orange"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [255, 112, 66]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_orange"],
       "layer2.texture": "Material Theme/assets/accent-orange/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-orange/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_orange"],
@@ -2902,9 +2902,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_orange"],
@@ -2925,7 +2925,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_orange"],
@@ -2935,7 +2935,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-orange/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -2945,7 +2945,7 @@
       "layer3.texture": "Material Theme/assets/accent-orange/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2955,7 +2955,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2965,7 +2965,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2975,7 +2975,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2985,37 +2985,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-orange/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_orange"],
@@ -3023,9 +3023,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_orange"],
@@ -3034,9 +3034,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_orange"],
@@ -3044,123 +3044,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_orange"],
       "viewport_color": [255, 112, 66, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -3168,9 +3168,9 @@
       "layer1.texture": "Material Theme/assets/accent-orange/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_orange"],
@@ -3178,121 +3178,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-orange/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_orange"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-orange/folder_dup--hover.png"
     },
-  
+
   // Yellow Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_yellow"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-yellow/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_yellow"],
       "layer0.tint": [255, 160, 0],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_yellow"],
       "layer0.tint": [255, 160, 0],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_yellow"],
       "match_fg": [255, 160, 0],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_yellow"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_yellow", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-yellow/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-yellow/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_yellow"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [255, 160, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_yellow"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [255, 160, 0]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_yellow"],
       "layer2.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-yellow/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_yellow"],
@@ -3319,9 +3319,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_yellow"],
@@ -3342,7 +3342,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_yellow"],
@@ -3352,7 +3352,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -3362,7 +3362,7 @@
       "layer3.texture": "Material Theme/assets/accent-yellow/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3372,7 +3372,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3382,7 +3382,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3392,7 +3392,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3402,37 +3402,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-yellow/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_yellow"],
@@ -3440,9 +3440,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_yellow"],
@@ -3451,9 +3451,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_yellow"],
@@ -3461,123 +3461,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_yellow"],
       "viewport_color": [255, 160, 0, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -3585,9 +3585,9 @@
       "layer1.texture": "Material Theme/assets/accent-yellow/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_yellow"],
@@ -3595,121 +3595,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-yellow/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_yellow"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-yellow/folder_dup--hover.png"
     },
-  
+
   // Indigo Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_indigo"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-indigo/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_indigo"],
       "layer0.tint": [92, 107, 192],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_indigo"],
       "layer0.tint": [92, 107, 192],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_indigo"],
       "match_fg": [92, 107, 192],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_indigo"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_indigo", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-indigo/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-indigo/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_indigo"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [92, 107, 192]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_indigo"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [92, 107, 192]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_indigo"],
       "layer2.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-indigo/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_indigo"],
@@ -3736,9 +3736,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_indigo"],
@@ -3759,7 +3759,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_indigo"],
@@ -3769,7 +3769,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -3779,7 +3779,7 @@
       "layer3.texture": "Material Theme/assets/accent-indigo/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3789,7 +3789,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3799,7 +3799,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3809,7 +3809,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3819,37 +3819,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-indigo/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_indigo"],
@@ -3857,9 +3857,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_indigo"],
@@ -3868,9 +3868,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_indigo"],
@@ -3878,123 +3878,128 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
+    {
+      "class": "quick_panel_detail_label",
+      "link_color": "#F3E5F5"
+    },
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_indigo"],
       "viewport_color": [92, 107, 192, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -4002,9 +4007,9 @@
       "layer1.texture": "Material Theme/assets/accent-indigo/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_indigo"],
@@ -4012,121 +4017,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-indigo/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_indigo"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-indigo/folder_dup--hover.png"
     },
-  
+
   // Pink Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_pink"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-pink/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_pink"],
       "layer0.tint": [255, 64, 129],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_pink"],
       "layer0.tint": [255, 64, 129],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_pink"],
       "match_fg": [255, 64, 129],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_pink"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_pink", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-pink/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-pink/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_pink"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [255, 64, 129]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_pink"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [255, 64, 129]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_pink"],
       "layer2.texture": "Material Theme/assets/accent-pink/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-pink/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_pink"],
@@ -4153,9 +4158,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_pink"],
@@ -4176,7 +4181,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_pink"],
@@ -4186,7 +4191,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-pink/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -4196,7 +4201,7 @@
       "layer3.texture": "Material Theme/assets/accent-pink/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4206,7 +4211,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4216,7 +4221,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4226,7 +4231,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4236,37 +4241,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-pink/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_pink"],
@@ -4274,9 +4279,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_pink"],
@@ -4285,9 +4290,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_pink"],
@@ -4295,123 +4300,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_pink"],
       "viewport_color": [255, 64, 129, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -4419,9 +4424,9 @@
       "layer1.texture": "Material Theme/assets/accent-pink/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_pink"],
@@ -4429,121 +4434,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-pink/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_pink"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-pink/folder_dup--hover.png"
     },
-  
+
   // Blue Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_blue"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-blue/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_blue"],
       "layer0.tint": [41, 121, 255],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_blue"],
       "layer0.tint": [41, 121, 255],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_blue"],
       "match_fg": [41, 121, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_blue"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_blue", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-blue/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-blue/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_blue"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [41, 121, 255]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_blue"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [41, 121, 255]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_blue"],
       "layer2.texture": "Material Theme/assets/accent-blue/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-blue/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_blue"],
@@ -4570,9 +4575,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_blue"],
@@ -4593,7 +4598,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_blue"],
@@ -4603,7 +4608,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-blue/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -4613,7 +4618,7 @@
       "layer3.texture": "Material Theme/assets/accent-blue/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4623,7 +4628,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4633,7 +4638,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4643,7 +4648,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4653,37 +4658,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-blue/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_blue"],
@@ -4691,9 +4696,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_blue"],
@@ -4702,9 +4707,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_blue"],
@@ -4712,123 +4717,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_blue"],
       "viewport_color": [41, 121, 255, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -4836,9 +4841,9 @@
       "layer1.texture": "Material Theme/assets/accent-blue/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_blue"],
@@ -4846,121 +4851,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-blue/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_blue"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-blue/folder_dup--hover.png"
     },
-  
+
   // Cyan Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_cyan"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-cyan/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_cyan"],
       "layer0.tint": [0, 188, 212],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_cyan"],
       "layer0.tint": [0, 188, 212],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_cyan"],
       "match_fg": [0, 188, 212],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_cyan"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_cyan", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-cyan/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-cyan/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_cyan"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [0, 188, 212]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_cyan"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [0, 188, 212]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_cyan"],
       "layer2.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-cyan/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_cyan"],
@@ -4987,9 +4992,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_cyan"],
@@ -5010,7 +5015,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_cyan"],
@@ -5020,7 +5025,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -5030,7 +5035,7 @@
       "layer3.texture": "Material Theme/assets/accent-cyan/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5040,7 +5045,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5050,7 +5055,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5060,7 +5065,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5070,37 +5075,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-cyan/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_cyan"],
@@ -5108,9 +5113,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_cyan"],
@@ -5119,9 +5124,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_cyan"],
@@ -5129,123 +5134,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_cyan"],
       "viewport_color": [0, 188, 212, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -5253,9 +5258,9 @@
       "layer1.texture": "Material Theme/assets/accent-cyan/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_cyan"],
@@ -5263,121 +5268,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-cyan/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_cyan"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-cyan/folder_dup--hover.png"
     },
-  
+
   // Bright Teal Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_bright-teal"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.tint": [100, 255, 218],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.tint": [100, 255, 218],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_bright-teal"],
       "match_fg": [100, 255, 218],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_bright-teal"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_bright-teal", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-bright-teal/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_bright-teal"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [100, 255, 218]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_bright-teal"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [100, 255, 218]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_bright-teal"],
       "layer2.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-bright-teal/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5404,9 +5409,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5427,7 +5432,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5437,7 +5442,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -5447,7 +5452,7 @@
       "layer3.texture": "Material Theme/assets/accent-bright-teal/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5457,7 +5462,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5467,7 +5472,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5477,7 +5482,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5487,37 +5492,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5525,9 +5530,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5536,9 +5541,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5546,123 +5551,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_bright-teal"],
       "viewport_color": [100, 255, 218, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -5670,9 +5675,9 @@
       "layer1.texture": "Material Theme/assets/accent-bright-teal/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5680,121 +5685,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_bright-teal"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/folder_dup--hover.png"
     },
-  
+
   // Acid Lime Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_acid-lime"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.tint": [198, 255, 0],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.tint": [198, 255, 0],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_acid-lime"],
       "match_fg": [198, 255, 0],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_acid-lime"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_acid-lime", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-acid-lime/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_acid-lime"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [198, 255, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_acid-lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [198, 255, 0]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_acid-lime"],
       "layer2.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-acid-lime/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5821,9 +5826,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5844,7 +5849,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5854,7 +5859,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -5864,7 +5869,7 @@
       "layer3.texture": "Material Theme/assets/accent-acid-lime/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5874,7 +5879,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5884,7 +5889,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5894,7 +5899,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5904,37 +5909,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5942,9 +5947,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5953,9 +5958,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5963,123 +5968,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_acid-lime"],
       "viewport_color": [198, 255, 0, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -6087,9 +6092,9 @@
       "layer1.texture": "Material Theme/assets/accent-acid-lime/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_acid-lime"],
@@ -6097,121 +6102,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_acid-lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/folder_dup--hover.png"
     },
-  
+
   // Graphite Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_graphite"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-graphite/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_graphite"],
       "layer0.tint": [97, 97, 97],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_graphite"],
       "layer0.tint": [97, 97, 97],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_graphite"],
       "match_fg": [97, 97, 97],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_graphite"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_graphite", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-graphite/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-graphite/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_graphite"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [97, 97, 97]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_graphite"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [97, 97, 97]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_graphite"],
       "layer2.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-graphite/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_graphite"],
@@ -6238,9 +6243,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_graphite"],
@@ -6261,7 +6266,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_graphite"],
@@ -6271,7 +6276,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -6281,7 +6286,7 @@
       "layer3.texture": "Material Theme/assets/accent-graphite/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6291,7 +6296,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6301,7 +6306,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6311,7 +6316,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6321,37 +6326,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-graphite/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_graphite"],
@@ -6359,9 +6364,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_graphite"],
@@ -6370,9 +6375,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_graphite"],
@@ -6380,123 +6385,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_graphite"],
       "viewport_color": [97, 97, 97, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -6504,9 +6509,9 @@
       "layer1.texture": "Material Theme/assets/accent-graphite/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_graphite"],
@@ -6514,121 +6519,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-graphite/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_graphite"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-graphite/folder_dup--hover.png"
     },
-  
+
   // Breaking Bad Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_brba"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-brba/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_brba"],
       "layer0.tint": [56, 142, 60],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_brba"],
       "layer0.tint": [56, 142, 60],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_brba"],
       "match_fg": [56, 142, 60],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_brba"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_brba", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-brba/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-brba/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_brba"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [56, 142, 60]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_brba"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [56, 142, 60]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_brba"],
       "layer2.texture": "Material Theme/assets/accent-brba/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-brba/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_brba"],
@@ -6655,9 +6660,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_brba"],
@@ -6678,7 +6683,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_brba"],
@@ -6688,7 +6693,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-brba/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -6698,7 +6703,7 @@
       "layer3.texture": "Material Theme/assets/accent-brba/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6708,7 +6713,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6718,7 +6723,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6728,7 +6733,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6738,37 +6743,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-brba/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_brba"],
@@ -6776,9 +6781,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_brba"],
@@ -6787,9 +6792,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_brba"],
@@ -6797,123 +6802,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_brba"],
       "viewport_color": [56, 142, 60, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -6921,9 +6926,9 @@
       "layer1.texture": "Material Theme/assets/accent-brba/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_brba"],
@@ -6931,121 +6936,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-brba/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_brba"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-brba/folder_dup--hover.png"
     },
-  
+
   // Sky Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_sky"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-sky/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_sky"],
       "layer0.tint": [132, 255, 255],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_sky"],
       "layer0.tint": [132, 255, 255],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_sky"],
       "match_fg": [132, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_sky"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_sky", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-sky/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-sky/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_sky"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [132, 255, 255]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_sky"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [132, 255, 255]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_sky"],
       "layer2.texture": "Material Theme/assets/accent-sky/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-sky/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_sky"],
@@ -7072,9 +7077,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_sky"],
@@ -7095,7 +7100,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_sky"],
@@ -7105,7 +7110,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-sky/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -7115,7 +7120,7 @@
       "layer3.texture": "Material Theme/assets/accent-sky/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7125,7 +7130,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7135,7 +7140,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7145,7 +7150,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7155,37 +7160,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-sky/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_sky"],
@@ -7193,9 +7198,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_sky"],
@@ -7204,9 +7209,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_sky"],
@@ -7214,123 +7219,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_sky"],
       "viewport_color": [132, 255, 255, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -7338,9 +7343,9 @@
       "layer1.texture": "Material Theme/assets/accent-sky/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_sky"],
@@ -7348,121 +7353,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-sky/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_sky"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-sky/folder_dup--hover.png"
     },
-  
+
   // Tomato Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_tomato"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-tomato/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_tomato"],
       "layer0.tint": [244, 67, 54],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_tomato"],
       "layer0.tint": [244, 67, 54],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_tomato"],
       "match_fg": [244, 67, 54],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_tomato"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_tomato", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-tomato/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-tomato/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_tomato"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [244, 67, 54]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_tomato"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [244, 67, 54]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_tomato"],
       "layer2.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-tomato/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_tomato"],
@@ -7489,9 +7494,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_tomato"],
@@ -7512,7 +7517,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_tomato"],
@@ -7522,7 +7527,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -7532,7 +7537,7 @@
       "layer3.texture": "Material Theme/assets/accent-tomato/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7542,7 +7547,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7552,7 +7557,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7562,7 +7567,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7572,37 +7577,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-tomato/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_tomato"],
@@ -7610,9 +7615,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_tomato"],
@@ -7621,9 +7626,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_tomato"],
@@ -7631,123 +7636,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_tomato"],
       "viewport_color": [244, 67, 54, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -7755,9 +7760,9 @@
       "layer1.texture": "Material Theme/assets/accent-tomato/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_tomato"],
@@ -7765,47 +7770,47 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-tomato/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_tomato"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-tomato/folder_dup--hover.png"
     },
-  
-  
-  
+
+
+
   // @ THEME OPTIONS
   // Options override
   // =========================================================================
-  
+
     // Tabs size Settings
-  
+
     {
       "class": "tabset_control",
       "settings": ["material_theme_small_tab"],
       "tab_height": 36,
       "content_margin": [12, 0, 8, 0]
     },
-  
+
     {
       "class": "tabset_control",
       "settings": ["material_theme_tabs_autowidth"],
       "tab_width": 0
     },
-  
+
     {
       "class": "tabset_control",
       "settings": ["!enable_tab_scrolling"],
       "content_margin": [0, 0, 8, 0],
     },
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_small_tab"],
       "content_margin": [12, 8, 6, 4],
     },
-  
+
     // Tabs separator
     {
       "class": "tab_control",
@@ -7814,17 +7819,17 @@
       "layer3.inner_margin": [1, 1],
       "layer3.opacity": 1.0,
     },
-  
+
       // Tab Labels
-  
+
     {
       "class": "tab_label",
       "settings": ["material_theme_bold_tab"],
       "font.bold": true
     },
-  
+
       // Disable Folder animation
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation"],
@@ -7833,9 +7838,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/commons/folder--hover.png",
     },
-  
+
       // Disable Folder animation
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders"],
@@ -7844,11 +7849,11 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/commons/arrow_folder--opened.png",
     },
-  
+
       // Folder hover no animation
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_lime"],
@@ -7857,7 +7862,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-lime/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -7866,9 +7871,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-lime/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_purple"],
@@ -7877,7 +7882,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-purple/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -7886,9 +7891,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-purple/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_red"],
@@ -7897,7 +7902,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-red/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_red"],
@@ -7906,9 +7911,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-red/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_orange"],
@@ -7917,7 +7922,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-orange/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -7926,9 +7931,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-orange/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_yellow"],
@@ -7937,7 +7942,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -7946,9 +7951,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-yellow/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_indigo"],
@@ -7957,7 +7962,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -7966,9 +7971,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-indigo/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_pink"],
@@ -7977,7 +7982,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-pink/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -7986,9 +7991,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-pink/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_blue"],
@@ -7997,7 +8002,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-blue/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -8006,9 +8011,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-blue/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_cyan"],
@@ -8017,7 +8022,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -8026,9 +8031,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-cyan/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_bright-teal"],
@@ -8037,7 +8042,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -8046,9 +8051,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-bright-teal/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_acid-lime"],
@@ -8057,7 +8062,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -8066,9 +8071,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-acid-lime/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_graphite"],
@@ -8077,7 +8082,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -8086,9 +8091,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-graphite/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_brba"],
@@ -8097,7 +8102,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-brba/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -8106,9 +8111,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-brba/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_sky"],
@@ -8117,7 +8122,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-sky/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -8126,9 +8131,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-sky/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_tomato"],
@@ -8137,7 +8142,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -8146,26 +8151,26 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-tomato/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
       // Small status bar
-  
+
     {
       "class": "status_container",
       "settings": ["material_theme_small_statusbar"],
       "content_margin": [12, 6, 12, 6],
     },
-  
+
       // Tree Indicator
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_disable_tree_indicator"],
       "attributes": ["selected"],
       "layer1.opacity": 0.0
     },
-  
+
     // Status bar panel
     {
       "class": "panel_control",
@@ -8174,74 +8179,74 @@
       "layer1.opacity": 0.2,
       "layer1.inner_margin": [2, 2, 2, 2],
     },
-  
+
       // Contrast mode
-  
+
     {
       "class": "sidebar_container",
       "settings": ["material_theme_contrast_mode"],
       "layer1.opacity": 0.2
     },
-  
+
     {
       "class": "sidebar_tree",
       "settings": ["material_theme_contrast_mode"],
       "layer1.opacity": 0.2
     },
-  
+
     {
       "class": "status_bar",
       "settings": ["material_theme_contrast_mode"],
       "layer1.opacity": 0.2
     },
-  
+
       // Compact mode
-  
+
     {
       "class": "sidebar_tree",
       "settings": ["material_theme_compact_sidebar"],
       "row_padding": [24, 5]
     },
-  
+
     {
       "class": "panel_control",
       "settings": ["material_theme_compact_panel"],
       "content_margin": [0, 0, 0, 0],
     },
-  
+
       // Filetype icons in sidebar
-  
+
     {
       "class": "icon_file_type",
       "settings": ["material_theme_disable_fileicons"],
       "layer0.opacity": 0,
       "content_margin": [0, 0]
     },
-  
+
       // Bigger file_type icons
-  
+
     {
       "class": "icon_file_type",
       "settings": ["material_theme_big_fileicons"],
       "content_margin": [11, 11]
     },
-  
+
     {
       "class": "icon_file_type",
       "settings": ["material_theme_big_fileicons"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "content_margin": [11, 11]
     },
-  
+
         // Bright scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_bright_scrollbars"],
       "layer1.texture": "Material Theme/assets/commons/thumb_vertical.png",
       "layer1.opacity": 0.2
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -8249,9 +8254,9 @@
       "layer1.texture": "Material Theme/assets/commons/thumb_horizontal.png",
       "layer1.opacity": 0.2
     },
-  
+
       // Title bar (OS X 10.10+)
-  
+
     {
       "class": "title_bar",
       "settings": ["material_theme_titlebar"],
@@ -8259,214 +8264,214 @@
       "fg": [103, 110, 149],
       "bg": [41, 45, 62]
     },
-  
+
     {
       "class": "title_bar",
       "settings": ["material_theme_titlebar", "material_theme_contrast_mode"],
       "platforms": ["osx"],
       "fg": [103, 110, 149],
       "bg":
-        
+
           [33, 36, 50]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_lime", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [124, 179, 66],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_purple", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [171, 71, 188],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_red", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [229, 115, 115],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_orange", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [255, 112, 66],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_yellow", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [255, 160, 0],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_indigo", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [92, 107, 192],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_pink", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [255, 64, 129],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_blue", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [41, 121, 255],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_cyan", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [0, 188, 212],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_bright-teal", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [100, 255, 218],
       "fg":
-        
+
           [0, 0, 0]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_acid-lime", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [198, 255, 0],
       "fg":
-        
+
           [0, 0, 0]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_graphite", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [97, 97, 97],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_brba", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [56, 142, 60],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_sky", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [132, 255, 255],
       "fg":
-        
+
           [0, 0, 0]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_tomato", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [244, 67, 54],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
   //
 ]

--- a/Material-Theme.sublime-theme
+++ b/Material-Theme.sublime-theme
@@ -3879,6 +3879,11 @@
       "selected_match_fg": [92, 107, 192]
     },
 
+    {
+      "class": "quick_panel_detail_label",
+      "link_color": "#2196F3"
+    },
+
       // Panels data / score
 
     {

--- a/Material-Theme.sublime-theme
+++ b/Material-Theme.sublime-theme
@@ -4,58 +4,61 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [
-  //
-  
+  {
+      "class": "title_bar",
+      "style": "dark"
+  },
+
   // @EMPTY WINDOW
   // Style for empty (no tabs) window
   // =========================================================================
-  
+
     {
       "class": "sheet_container_control",
       "layer0.tint": [38, 50, 56],
       "layer0.opacity": 1.0
     },
-  
+
   // @GRID LAYOUT
   // Grid style
   // =========================================================================
-  
+
     {
       "class": "grid_layout_control",
       "border_size": 1,
       "border_color": [34, 45, 51]
     },
-  
-  
+
+
   // @ DIALOG POPUP
   // Dialog popup style and progressbar
   // =========================================================================
-  
+
     {
       "class": "progress_gauge_control",
       "layer0.tint": [128, 203, 196],
       "layer0.opacity": 1.0,
       "content_margin": [0, 6]
     },
-  
+
     {
       "class": "dialog",
       "layer0.tint": [38, 50, 56],
       "layer0.opacity": 1.0
     },
-  
+
     {
       "class": "progress_bar_control",
       "layer0.tint": [38, 50, 56],
       "layer0.opacity": 1.0,
     },
-  
-  
-  
+
+
+
   // @ CODE FOLDING
   // Folding arrow setting and behavioring
   // =========================================================================
-  
+
     {
       "class": "fold_button_control",
       "layer0.texture": "Material Theme/assets/default/fold_right.png",
@@ -66,41 +69,41 @@
       "layer1.inner_margin": 0,
       "content_margin": [9, 7, 8, 6]
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["hover"],
       "layer0.opacity": 0.0,
       "layer1.opacity": 1.0
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "layer0.texture": "Material Theme/assets/default/fold_down.png",
       "layer1.texture": "Material Theme/assets/commons/fold_down--hover.png"
     },
-  
-  
+
+
   // @ AUTOCOMPLETE
   //  Autocomplete popup setting and behavioring
   // =========================================================================
-  
-  
+
+
     {
       "class": "popup_control",
       "layer0.tint": [38, 50, 56, 255],
       "layer0.opacity": 1.0,
       "content_margin": [0, 0]
     },
-  
+
     {
       "class": "auto_complete",
       "row_padding": [12, 6],
       "layer0.tint": [38, 50, 56, 255],
       "layer0.opacity": 1.0
     },
-  
+
     {
       "class": "auto_complete_label",
       "fg": [176, 190, 197, 255],
@@ -108,24 +111,24 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
     {
       "class": "table_row",
       "layer0.tint": [84, 110, 122],
       "layer0.opacity": 0.0,
     },
-  
+
     {
       "class": "table_row",
       "attributes": ["selected"],
       "layer0.opacity": 0.3
     },
-  
-  
+
+
   /* @ TOOLTIP
    * Tooltip setting and behavioring
   ========================================================================= */
-  
+
     {
       "class": "tool_tip_control",
       "layer0.tint": [128, 203, 196],
@@ -133,17 +136,17 @@
       "layer0.opacity": 1.0,
       "content_margin": [16, 8]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "color": [0, 0, 0, 150]
     },
-  
-  
+
+
   /* @OVERLAY PANELS
    * Overlay panels setting and behavioring
   ========================================================================= */
-  
+
     // Command Panel
      {
         "class": "overlay_control",
@@ -155,53 +158,53 @@
         "layer1.opacity": 1.0,
         "content_margin": [13, 13, 13, 33]
      },
-  
+
       // Command Panel list item style (cmd + shift + p)
-  
+
     {
       "class": "mini_quick_panel_row",
       "layer0.tint": [38, 50, 56, 0],
       "layer0.inner_margin": [2, 2, 2, 2],
       "layer0.opacity": 1.0
     },
-  
+
       // Command Panel selected list item style (cmd + p)
-  
+
     {
       "class": "mini_quick_panel_row",
       "attributes": ["selected"],
       "layer0.tint": [84, 110, 122],
       "layer0.opacity": 0.3
     },
-  
+
       // Quick panel project setting (project manager) (cmd + ctrl + p)
-  
+
     {
       "class": "quick_panel",
       "row_padding": [32, 12],
       "layer0.tint": [38, 50, 56],
       "layer0.opacity": 1.0
     },
-  
+
       // Quick Panel row default style (project manager)
-  
+
     {
       "class": "quick_panel_row",
       "layer0.tint": [38, 50, 56, 0],
       "layer0.opacity": 1.0
     },
-  
+
       // Row panel style inside command panel (cmd + shift + p)
-  
+
     {
       "class": "quick_panel_row",
       "parents": [{"class": "overlay_control"}],
       "layer0.tint": [38, 50, 56, 0],
       "layer0.opacity": 1.0
     },
-  
+
       // Quick panel (project) style inside overlay_control (cmd + shift + p)
-  
+
     {
       "class": "quick_panel",
       "parents": [{"class": "overlay_control"}],
@@ -209,9 +212,9 @@
       "layer0.tint": [38, 50, 56, 0],
       "layer0.opacity": 1.0
     },
-  
+
       // Quick Panel selected list item style
-  
+
     {
       "class": "quick_panel_row",
       "attributes": ["selected"],
@@ -219,9 +222,9 @@
       "layer0.opacity": 0.3,
       "layer1.opacity": 0.0
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "fg": [176, 190, 197, 255],
@@ -229,9 +232,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "parents": [{"class": "overlay_control"}],
@@ -240,9 +243,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "fg": [84, 110, 122, 255],
@@ -250,20 +253,20 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [128, 203, 196, 255]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "quick_panel_score_label",
       "fg": [176, 190, 197, 255],
       "selected_fg": [255, 255, 255, 255]
     },
-  
-  
+
+
   /* @ TABS
    * Tabs settings and behavioring
   ========================================================================= */
-  
+
     {
       "class": "tabset_control",
       "layer0.opacity": 1.0,
@@ -283,25 +286,25 @@
       "settings": ["mouse_wheel_switches_tabs", "!enable_tab_scrolling"],
       "mouse_wheel_switch": true
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
-  
+
       "layer0.tint": [38, 50, 56],
       "layer0.inner_margin": [24, 0],
       "layer0.opacity": 1.0,
       "tint_index": 0,
-  
+
       "layer1.texture": "Material Theme/assets/default/tab_current.png",
       "layer1.inner_margin": [0, 0],
       "layer1.opacity": 0.0,
-  
+
       "layer2.tint": [128, 203, 196, 0],
       "layer2.inner_margin": [0, 0],
       "layer2.opacity": { "target": 0.0, "speed": 3.0, "interpolation": "smoothstep" },
-  
+
       "layer3.inner_margin": [0, 0],
       "layer3.opacity": { "target": 1.0, "speed": 2.0, "interpolation": "smoothstep" },
       "layer3.texture": {
@@ -324,41 +327,41 @@
               "loop": false,
               "frame_time": 0.015,
       },
-  
+
       "content_margin": [16, 0, 8, 0],
       "max_margin_trim": 0,
       "hit_test_level": 0.4
     },
-  
+
       // Selected current tab
-  
+
     {
       "class": "tab_control", "attributes": ["selected"],
       "layer1.opacity": 1.0,
       "layer2.opacity": 0.0,
       "layer3.opacity": 0.0
     },
-  
+
       // Hovered current tab
-  
+
     {
       "class": "tab_control", "attributes": ["hover"],
       "layer1.opacity": 1.0,
       "layer2.opacity": { "target": 0.6, "speed": 5.0, "interpolation": "smoothstep" },
       "layer3.opacity": { "target": 0.0, "speed": 2.0, "interpolation": "smoothstep" }
     },
-  
+
       // Selected current tab
-  
+
     {
       "class": "tab_control", "attributes": ["selected","hover"],
       "layer1.opacity": 1.0,
       "layer2.opacity": { "target": 0.6, "speed": 5.0, "interpolation": "smoothstep" },
       "layer3.opacity": 0.0
     },
-  
+
       // Tab Labels
-  
+
     {
       "class": "tab_label",
       "fg": [84, 110, 122, 255],
@@ -368,9 +371,9 @@
       "font.italic": false,
       "font.bold": false
     },
-  
+
       // Tab selected label color
-  
+
     {
       "class": "tab_label",
       "parents": [{"class": "tab_control", "attributes": ["selected"]}],
@@ -378,36 +381,36 @@
       "shadow_color": [255, 255, 255, 0],
       "shadow_offset": [0, 0]
     },
-  
+
     {
       "class": "tab_label",
       "attributes": ["transient"],
       "font.italic": true
     },
-  
+
       // Tab Close Buttons
     {
       "class": "tab_close_button",
       "content_margin": [0, 0],
-  
+
        // Close Icon
       "layer0.texture": "Material Theme/assets/default/close_icon.png",
       "layer0.opacity": 1,
       "layer0.inner_margin": 0,
-  
+
       // Close Icon Hover
       "layer1.texture": "Material Theme/assets/commons/close_icon--hover.png",
       "layer1.opacity": { "target": 0.0, "speed": 5.0, "interpolation": "smoothstep" },
-  
+
        // Dirty Icon
       "layer2.texture": "Material Theme/assets/default/dirty_icon.png",
       "layer2.inner_margin": 0,
-  
+
       // Dirty Icon Hover
       "layer3.texture": "Material Theme/assets/commons/dirty_icon--hover.png",
       "layer3.opacity": { "target": 0.0, "speed": 5.0, "interpolation": "smoothstep" }
     },
-  
+
       // Default
     {
       "class": "tab_close_button",
@@ -440,7 +443,7 @@
       "layer3.opacity": 1, // Dirty Icon Hover
       "content_margin": [8,8],
     },
-  
+
       // Dirty tab on hover
     {
       "class": "tab_close_button",
@@ -481,13 +484,13 @@
       "layer1.opacity": { "target": 0.0, "speed": 8.0, "interpolation": "smoothstep" },
       "layer1.inner_margin": 0,
     },
-  
+
     {
       "class": "scroll_tabs_left_button",
       "attributes": ["hover"],
       "layer1.opacity": { "target": 1.0, "speed": 8.0, "interpolation": "smoothstep" }
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "content_margin": [14, 7],
@@ -498,13 +501,13 @@
       "layer1.opacity": { "target": 0.0, "speed": 8.0, "interpolation": "smoothstep" },
       "layer1.inner_margin": 0,
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "attributes": ["hover"],
       "layer1.opacity": { "target": 1.0, "speed": 8.0, "interpolation": "smoothstep" }
     },
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "content_margin": [12, 12],
@@ -515,19 +518,19 @@
       "layer1.opacity": { "target": 0.0, "speed": 8.0, "interpolation": "smoothstep" },
       "layer1.inner_margin": 0,
     },
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "attributes": ["hover"],
       "layer1.opacity": { "target": 1.0, "speed": 8.0, "interpolation": "smoothstep" }
     },
-  
-  
+
+
   /* @ SIDEBAR
    * Sidebar panel settings and behavioring
   ========================================================================= */
-  
-  
+
+
     {
       "class": "sidebar_container",
       "content_margin": [0, 12, 0, 0],
@@ -549,7 +552,7 @@
       "layer1.tint": [0,0,0],
       "layer1.opacity": 0.0
     },
-  
+
     {
       "class": "sidebar_heading",
       "color": [207, 216, 220],
@@ -558,7 +561,7 @@
       "shadow_color": [250, 250, 250, 0],
       "shadow_offset": [0, 0],
     },
-  
+
     {
       "class": "sidebar_heading",
       "parents":
@@ -567,22 +570,22 @@
       ],
       "shadow_color": [160, 174, 192, 0],
     },
-  
+
     {
        "class": "tree_row",
        "layer1.texture": "Material Theme/assets/commons/tree_highlight.png",
        "layer1.opacity": { "target": 0.0, "speed": 5.0, "interpolation": "smoothstep" },
        "layer1.inner_margin": [22, 8, 0, 0]
     },
-  
+
     {
        "class": "tree_row",
        "attributes": ["selected"],
        "layer1.opacity": { "target": 1.0, "speed": 5.0, "interpolation": "smoothstep" }
     },
-  
+
       // Bullet Tree Indicator
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_bullet_tree_indicator"],
@@ -590,7 +593,7 @@
       "layer1.texture": "Material Theme/assets/commons/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "color": [96, 125, 139],
@@ -599,7 +602,7 @@
       "shadow_color": [255, 255, 255, 0],
       "shadow_offset": [0, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["hover"]}],
@@ -607,82 +610,82 @@
       "shadow_color": [255, 255, 255, 0],
       "shadow_offset": [0, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "font.bold": false,
       "color": [128, 203, 196]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expandable"]}],
       "color": [175, 189, 196]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expandable"]}],
       "settings": ["bold_folder_labels"],
       "font.bold": true
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expandable", "selected"]}],
       "color": [255, 255, 255]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [128, 203, 196]
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "settings": ["bold_folder_labels"],
       "font.bold": true
     },
-  
+
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expanded", "selected"]}],
       "color": [255, 255, 255]
     },
-  
+
     {
       "class": "sidebar_label",
       "attributes": ["transient"],
       "font.italic": false
     },
-  
+
       // File icons and folder
-  
+
     {
       "class": "icon_file_type",
       // layer0.texture is filled in by code with the relevant icon name
       "layer0.opacity": 0.6,
       "content_margin": [9, 9]
     },
-  
+
     {
       "class": "icon_file_type",
       "parents": [{"class": "tree_row", "attributes": ["hover"]}],
       "layer0.opacity": { "target": 1.0, "speed": 3.0, "interpolation": "smoothstep" }
     },
-  
+
     {
       "class": "icon_file_type",
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "layer0.opacity": 1,
       "content_margin": [9, 9]
     },
-  
+
       // Secondary folder icon (original) used as main folder icon
-  
+
     {
       "class": "icon_folder",
       "content_margin": [11, 7],
@@ -695,7 +698,7 @@
       "layer3.texture": "Material Theme/assets/commons/folder_opened--hover.png",
       "layer3.opacity": 0.0,
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -708,7 +711,7 @@
       "layer3.texture": "Material Theme/assets/commons/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "parents":
@@ -719,7 +722,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0,
     },
-  
+
     {
       "class": "icon_folder",
       "parents":
@@ -730,7 +733,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0,
     },
-  
+
     {
       "class": "icon_folder",
       "parents":
@@ -762,8 +765,8 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0,
     },
-  
-  
+
+
       // Arrow icon folder Expandend - Hover
     {
       "class": "icon_folder",
@@ -771,7 +774,7 @@
       "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
       "layer3.texture": "Material Theme/assets/commons/arrow_folder--opened.png",
     },
-  
+
     {
       "class": "icon_folder",
       "parents":
@@ -780,9 +783,9 @@
       ],
       "layer1.texture": "Material Theme/assets/commons/folder--hover.png",
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "layer0.texture":
@@ -805,35 +808,35 @@
         "loop": true,
         "frame_time": 0.075,
       },
-  
+
       "layer0.opacity": 1.0,
       "content_margin": [8, 8]
     },
-  
+
       // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "layer0.texture": "Material Theme/assets/default/folder_dup.png",
       "layer0.opacity": 1.0,
       "content_margin": [11, 7]
     },
-  
+
     {
       "class": "icon_folder_dup",
       "parents":
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/commons/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/commons/folder_dup--hover.png"
     },
-  
+
       // Hidden arrow icon before folder
-  
+
     {
       "class": "disclosure_button_control",
       "layer0.texture": "Material Theme/assets/default/folder.png",
@@ -844,7 +847,7 @@
       "layer1.inner_margin": 0,
       "content_margin": [0, 0, 0, 0]
     },
-  
+
     {
       "class": "disclosure_button_control",
       "parents":
@@ -854,45 +857,45 @@
       "layer0.opacity": 0.0,
       "layer1.opacity": 1.0
     },
-  
+
     {
       "class": "disclosure_button_control",
       "attributes": ["expanded"],
       "layer0.texture": "Material Theme/assets/commons/folder_opened--hover.png",
     },
-  
+
     {
       "class": "tree_row",
       "layer0.tint": [38, 50, 56],
       "layer0.opacity": 0.0,
       "layer0.inner_margin": [1, 1]
     },
-  
+
     {
       "class": "tree_row",
       "attributes": ["selected"],
       "layer0.opacity": 1
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "content_margin": [8, 8],
-  
+
       // Default Close icon
       "layer0.texture": "Material Theme/assets/default/close_icon.png",
       "layer0.opacity": { "target": 0.0, "speed": 7.0, "interpolation": "smoothstep" },
       "layer0.inner_margin": [0,0],
-  
+
       // Hover close icon
       "layer1.texture": "Material Theme/assets/commons/close_icon--hover.png",
       "layer1.opacity": 0,
       "layer1.inner_margin": [0,0],
     },
-  
+
       // Opened file hover
-  
+
     {
       "class": "close_button",
       "parents":
@@ -904,28 +907,28 @@
       "layer0.opacity": { "target": 1.0, "speed": 7.0, "interpolation": "smoothstep" },
       "layer0.inner_margin": [0,0],
     },
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "layer0.texture": "Material Theme/assets/commons/dirty_icon--hover.png",
       "layer0.opacity": 1.0
     },
-  
+
     {
       "class": "close_button",
       "attributes": ["hover"],
       "layer0.opacity": 0,
       "layer1.opacity": 1.0
     },
-  
-  
+
+
   /* @ SCROLLBARS
    * Scrollbars settings and behavioring
   ========================================================================= */
-  
+
     // Normal Vertical scrollbar track
-  
+
     {
       "class": "scroll_bar_control",
       "layer0.tint": [38, 50, 56],
@@ -936,9 +939,9 @@
       "layer1.inner_margin": [0, 6],
       "blur": false
     },
-  
+
       // Normal Vertical scrollbar track inside overlay panel
-  
+
     // {
     //   "class": "scroll_bar_control",
     //   "parents": [{"class": "overlay_control"}],
@@ -947,9 +950,9 @@
     //   "layer0.inner_margin": [0, 6],
     //   "blur": false
     // },
-  
+
       // Normal horizontal scrollbar track
-  
+
     {
       "class": "scroll_bar_control",
       "attributes": ["horizontal"],
@@ -961,9 +964,9 @@
       "layer1.inner_margin": [6, 0],
       "blur": false
     },
-  
+
       // Normal horizontal scrollbar track inside overlay panel
-  
+
     // {
     //   "class": "scroll_bar_control",
     //   "attributes": ["horizontal"],
@@ -973,18 +976,18 @@
     //   "layer0.inner_margin": [0, 2],
     //   "blur": false
     // },
-  
+
       // Scrollbars corner
-  
+
     {
       "class": "scroll_corner_control",
       "layer0.texture": "Material Theme/assets/default/normal_bar_corner.png",
       "layer0.opacity": 1.0,
       "layer0.inner_margin": [1, 1]
     },
-  
+
       // Vertical puck controller
-  
+
     {
       "class": "puck_control",
       "layer0.tint": [38, 50, 255, 255],
@@ -996,9 +999,9 @@
       "content_margin": [6, 16],
       "blur": false
     },
-  
+
       // Horizontal puck controller
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -1008,34 +1011,34 @@
       "content_margin": [16, 6],
       "blur": false
     },
-  
+
     {
       "class": "scroll_area_control",
       "settings": ["overlay_scroll_bars"],
       "overlay": true
     },
-  
+
     {
       "class": "scroll_area_control",
       "settings": ["!overlay_scroll_bars"],
       "overlay": false // set to false for the original behavior
     },
-  
-  
+
+
     {
       "class": "scroll_area_control",
       "parents": [{"class": "overlay_control"}],
       "settings": ["overlay_scroll_bars"],
       "overlay": true // set to false for the original behavior
     },
-  
+
     {
       "class": "scroll_area_control",
       "parents": [{"class": "sidebar_container"}],
       "settings": ["!overlay_scroll_bars"],
       "overlay": false // set to false for the original behavior
     },
-  
+
     {
       "class": "scroll_bar_control",
       "settings": ["overlay_scroll_bars"],
@@ -1043,7 +1046,7 @@
       "layer0.inner_margin": [0, 5],
       "blur": true
     },
-  
+
     {
       "class": "scroll_bar_control",
       "settings": ["overlay_scroll_bars"],
@@ -1056,7 +1059,7 @@
       "layer1.opacity": 0.0,
       "blur": true
     },
-  
+
     {
       "class": "puck_control",
       "layer0.tint": [38, 50, 56],
@@ -1067,7 +1070,7 @@
       "content_margin": [6, 16],
       "blur": true
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -1079,20 +1082,20 @@
       "content_margin": [16, 6],
       "blur": true
     },
-  
-  
+
+
   // @ MINIMAP
   // Minimap settings and behavioring
   // =========================================================================
-  
-  
+
+
     {
       "class": "minimap_control",
       "settings": ["always_show_minimap_viewport"],
       "viewport_color": [128, 203, 196, 80],
       "viewport_opacity": 0.5,
     },
-  
+
     {
       "class": "minimap_control",
       "settings": ["!always_show_minimap_viewport"],
@@ -1105,15 +1108,15 @@
       "settings": ["!always_show_minimap_viewport"],
       "viewport_opacity": { "target": 0.4, "speed": 20.0, "interpolation": "smoothstep" },
     },
-  
-  
-  
+
+
+
   /* @ STATUS BAR
    * Status bar settings and behavioring
   ========================================================================= */
-  
+
     // All labels
-  
+
     {
       "class": "label_control",
       "color": [176, 190, 197],
@@ -1121,37 +1124,37 @@
       "shadow_offset": [0, 0],
       "font.bold": true
     },
-  
+
       // Status bar labels
-  
+
      {
         "class": "label_control",
         "parents": [{"class": "status_bar"}],
         "color": [120, 144, 156],
         "font.bold": false
     },
-  
+
       // Text field labels
-  
+
     {
       "class": "status_bar",
       "content_margin": [8, 0, 0, 0],
-  
+
       // Layer 0 base
       "layer0.tint": [38, 50, 56],
       "layer0.opacity": 1.0,
       "layer0.inner_margin": [2, 2],
-  
+
       // Visible tint layer
       "layer1.tint": [0,0,0],
       "layer1.opacity": 0.0,
     },
-  
+
     {
       "class": "status_container",
       "content_margin": [24, 12, 24, 12],
     },
-  
+
     {
       "class": "status_button",
       "layer0.tint": [38, 50, 56],
@@ -1161,7 +1164,7 @@
       "content_margin": [10, 2, 10, 3],
       "min_size": [75, 0]
     },
-  
+
     {
       "class": "status_button",
       "layer0.tint": [38, 50, 56],
@@ -1171,7 +1174,7 @@
       "content_margin": [10, 2, 10, 3],
       "min_size": [75, 0],
     },
-  
+
     // panel switcher
     {
       "class": "panel_button_control",
@@ -1179,19 +1182,19 @@
       "layer0.opacity": 1.0,
       "content_margin": [10, 10]
     },
-  
+
     {
       "class": "panel_button_control",
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/commons/overflow_menu--hover.png",
     },
-  
-  
+
+
   /* @ WIDGET PANEL
    * Widget, input, buttons settings and behavioring
   ========================================================================= */
-  
-  
+
+
     // Status bar panel
     {
       "class": "panel_control",
@@ -1203,9 +1206,9 @@
       "layer1.opacity": 1.0,
       "content_margin": [6, 14, 6, 8],
     },
-  
+
       // Status bar panel close icon
-  
+
     {
       "class": "panel_close_button",
       "layer0.texture": "Material Theme/assets/default/close_icon.png",
@@ -1214,16 +1217,16 @@
       "layer1.opacity": 0.0,
       "content_margin": [0, 0] // 8,8 to show
     },
-  
+
     {
       "class": "panel_close_button",
       "attributes": ["hover"],
       "layer0.opacity": 0.0,
       "layer1.opacity": 1.0,
     },
-  
+
       // Texline input
-  
+
     {
       "class": "text_line_control",
       "layer0.texture": "Material Theme/assets/default/input_field_border.png",
@@ -1232,10 +1235,10 @@
       "tint_index": 1,
       "content_margin": [10, 8, 16, 8]
     },
-  
-  
+
+
       // Textline input inside overlay panels
-  
+
     {
       "class": "text_line_control",
       "parents": [{"class": "overlay_control"}],
@@ -1243,12 +1246,12 @@
       "layer0.opacity": 1.0,
       "layer0.inner_margin": [32, 0, 32, 2],
       "layer0.draw_center": true,
-  
+
       "content_margin": [32, 8, 32, 8]
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "content_margin": [12, 12],
@@ -1264,28 +1267,28 @@
       "attributes": ["hover"],
       "layer1.opacity": 1.0
     },
-  
-  
+
+
   // @ BUTTONS
   // Buttons panels settings and behavioring
   // =========================================================================
-  
-  
+
+
     // Button labels
-  
+
     {
        "class": "label_control",
        "parents": [{"class": "button_control"}],
        "color": [96, 125, 139],
        "font.bold": true
     },
-  
+
     {
        "class": "label_control",
        "parents": [{"class": "button_control", "attributes": ["hover"]}],
        "color": [255,255,255]
     },
-  
+
     {
       "class": "button_control",
       "content_margin": [6, 12, 6, 12],
@@ -1316,7 +1319,7 @@
       "attributes": ["hover"],
       "layer2.opacity": { "target": 1.0, "speed": 5.0, "interpolation": "smoothstep" }
     },
-  
+
     // Small Icon Buttons
     {
       "class": "icon_button_control",
@@ -1327,11 +1330,11 @@
       "layer2.opacity": { "target": 0.0, "speed": 10.0, "interpolation": "smoothstep" },
       "content_margin": [10, 6]
     },
-  
-  
+
+
     /* Buttons icons settings
     ===================================================================== */
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
@@ -1341,16 +1344,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_regex",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "layer0.texture": "Material Theme/assets/commons/find_case--hover.png",
@@ -1359,16 +1362,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_case",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "layer0.texture": "Material Theme/assets/commons/find_word--hover.png",
@@ -1377,17 +1380,17 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
-  
+
+
      {
         "class": "icon_whole_word",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "layer0.texture": "Material Theme/assets/commons/find_wrap--hover.png",
@@ -1396,16 +1399,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_wrap",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "layer0.texture": "Material Theme/assets/commons/find_inselection--hover.png",
@@ -1414,17 +1417,17 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12,12]
     },
-  
-  
+
+
      {
         "class": "icon_in_selection",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "layer0.texture": "Material Theme/assets/commons/find_highlight--hover.png",
@@ -1433,16 +1436,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_highlight",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "layer0.texture": "Material Theme/assets/commons/replace_preserve_case--hover.png",
@@ -1451,16 +1454,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_preserve_case",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "layer0.texture": "Material Theme/assets/commons/find_context--hover.png",
@@ -1469,17 +1472,17 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
-  
+
+
      {
         "class": "icon_context",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "layer0.texture": "Material Theme/assets/commons/use_buffer--hover.png",
@@ -1488,16 +1491,16 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
      {
         "class": "icon_use_buffer",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
         "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
         "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
      },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "layer0.texture": "Material Theme/assets/commons/find_reverse--hover.png",
@@ -1506,122 +1509,122 @@
       "layer1.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "content_margin": [12, 12]
     },
-  
+
     {
       "class": "icon_reverse",
       "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
       "layer0.opacity": { "target": 1.0, "speed": 6.0, "interpolation": "smoothstep" },
       "layer1.opacity": { "target": 0.0, "speed": 6.0, "interpolation": "smoothstep" }
     },
-  
-  
+
+
   // Lime Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_lime"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-lime/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_lime"],
       "layer0.tint": [124, 179, 66],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_lime"],
       "layer0.tint": [124, 179, 66],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_lime"],
       "match_fg": [124, 179, 66],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_lime"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_lime", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-lime/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-lime/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_lime"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [124, 179, 66]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [124, 179, 66]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_lime"],
       "layer2.texture": "Material Theme/assets/accent-lime/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-lime/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_lime"],
@@ -1648,9 +1651,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_lime"],
@@ -1671,7 +1674,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_lime"],
@@ -1681,7 +1684,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-lime/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -1691,7 +1694,7 @@
       "layer3.texture": "Material Theme/assets/accent-lime/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1701,7 +1704,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1711,7 +1714,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1721,7 +1724,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -1731,37 +1734,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-lime/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_lime"],
@@ -1769,9 +1772,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_lime"],
@@ -1780,9 +1783,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_lime"],
@@ -1790,123 +1793,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [124, 179, 66]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_lime"],
       "layer0.texture": "Material Theme/assets/accent-lime/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_lime"],
       "viewport_color": [124, 179, 66, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_lime"],
       "layer1.texture": "Material Theme/assets/accent-lime/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -1914,9 +1917,9 @@
       "layer1.texture": "Material Theme/assets/accent-lime/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_lime"],
@@ -1924,121 +1927,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-lime/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-lime/folder_dup--hover.png"
     },
-  
+
   // Purple Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_purple"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-purple/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_purple"],
       "layer0.tint": [171, 71, 188],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_purple"],
       "layer0.tint": [171, 71, 188],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_purple"],
       "match_fg": [171, 71, 188],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_purple"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_purple", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-purple/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-purple/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_purple"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [171, 71, 188]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_purple"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [171, 71, 188]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_purple"],
       "layer2.texture": "Material Theme/assets/accent-purple/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-purple/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_purple"],
@@ -2065,9 +2068,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_purple"],
@@ -2088,7 +2091,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_purple"],
@@ -2098,7 +2101,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-purple/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -2108,7 +2111,7 @@
       "layer3.texture": "Material Theme/assets/accent-purple/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2118,7 +2121,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2128,7 +2131,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2138,7 +2141,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -2148,37 +2151,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-purple/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_purple"],
@@ -2186,9 +2189,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_purple"],
@@ -2197,9 +2200,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_purple"],
@@ -2207,123 +2210,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [171, 71, 188]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_purple"],
       "layer0.texture": "Material Theme/assets/accent-purple/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_purple"],
       "viewport_color": [171, 71, 188, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_purple"],
       "layer1.texture": "Material Theme/assets/accent-purple/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -2331,9 +2334,9 @@
       "layer1.texture": "Material Theme/assets/accent-purple/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_purple"],
@@ -2341,121 +2344,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-purple/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_purple"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-purple/folder_dup--hover.png"
     },
-  
+
   // Red Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_red"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-red/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_red"],
       "layer0.tint": [229, 115, 115],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_red"],
       "layer0.tint": [229, 115, 115],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_red"],
       "match_fg": [229, 115, 115],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_red"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_red", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-red/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-red/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_red"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [229, 115, 115]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_red"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [229, 115, 115]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_red"],
       "layer2.texture": "Material Theme/assets/accent-red/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-red/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_red"],
@@ -2482,9 +2485,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_red"],
@@ -2505,7 +2508,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_red"],
@@ -2515,7 +2518,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-red/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -2525,7 +2528,7 @@
       "layer3.texture": "Material Theme/assets/accent-red/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2535,7 +2538,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2545,7 +2548,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2555,7 +2558,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_red"],
@@ -2565,37 +2568,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-red/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_red"],
@@ -2603,9 +2606,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_red"],
@@ -2614,9 +2617,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_red"],
@@ -2624,123 +2627,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [229, 115, 115]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_red"],
       "layer0.texture": "Material Theme/assets/accent-red/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_red"],
       "viewport_color": [229, 115, 115, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_red"],
       "layer1.texture": "Material Theme/assets/accent-red/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -2748,9 +2751,9 @@
       "layer1.texture": "Material Theme/assets/accent-red/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_red"],
@@ -2758,121 +2761,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-red/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_red"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-red/folder_dup--hover.png"
     },
-  
+
   // Orange Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_orange"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-orange/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_orange"],
       "layer0.tint": [255, 112, 66],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_orange"],
       "layer0.tint": [255, 112, 66],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_orange"],
       "match_fg": [255, 112, 66],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_orange"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_orange", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-orange/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-orange/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_orange"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [255, 112, 66]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_orange"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [255, 112, 66]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_orange"],
       "layer2.texture": "Material Theme/assets/accent-orange/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-orange/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_orange"],
@@ -2899,9 +2902,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_orange"],
@@ -2922,7 +2925,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_orange"],
@@ -2932,7 +2935,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-orange/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -2942,7 +2945,7 @@
       "layer3.texture": "Material Theme/assets/accent-orange/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2952,7 +2955,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2962,7 +2965,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2972,7 +2975,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -2982,37 +2985,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-orange/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_orange"],
@@ -3020,9 +3023,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_orange"],
@@ -3031,9 +3034,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_orange"],
@@ -3041,123 +3044,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 112, 66]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_orange"],
       "layer0.texture": "Material Theme/assets/accent-orange/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_orange"],
       "viewport_color": [255, 112, 66, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_orange"],
       "layer1.texture": "Material Theme/assets/accent-orange/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -3165,9 +3168,9 @@
       "layer1.texture": "Material Theme/assets/accent-orange/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_orange"],
@@ -3175,121 +3178,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-orange/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_orange"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-orange/folder_dup--hover.png"
     },
-  
+
   // Yellow Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_yellow"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-yellow/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_yellow"],
       "layer0.tint": [255, 160, 0],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_yellow"],
       "layer0.tint": [255, 160, 0],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_yellow"],
       "match_fg": [255, 160, 0],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_yellow"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_yellow", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-yellow/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-yellow/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_yellow"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [255, 160, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_yellow"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [255, 160, 0]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_yellow"],
       "layer2.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-yellow/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_yellow"],
@@ -3316,9 +3319,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_yellow"],
@@ -3339,7 +3342,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_yellow"],
@@ -3349,7 +3352,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -3359,7 +3362,7 @@
       "layer3.texture": "Material Theme/assets/accent-yellow/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3369,7 +3372,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3379,7 +3382,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3389,7 +3392,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -3399,37 +3402,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-yellow/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_yellow"],
@@ -3437,9 +3440,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_yellow"],
@@ -3448,9 +3451,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_yellow"],
@@ -3458,123 +3461,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 160, 0]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_yellow"],
       "layer0.texture": "Material Theme/assets/accent-yellow/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_yellow"],
       "viewport_color": [255, 160, 0, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_yellow"],
       "layer1.texture": "Material Theme/assets/accent-yellow/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -3582,9 +3585,9 @@
       "layer1.texture": "Material Theme/assets/accent-yellow/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_yellow"],
@@ -3592,121 +3595,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-yellow/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_yellow"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-yellow/folder_dup--hover.png"
     },
-  
+
   // Indigo Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_indigo"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-indigo/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_indigo"],
       "layer0.tint": [92, 107, 192],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_indigo"],
       "layer0.tint": [92, 107, 192],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_indigo"],
       "match_fg": [92, 107, 192],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_indigo"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_indigo", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-indigo/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-indigo/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_indigo"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [92, 107, 192]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_indigo"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [92, 107, 192]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_indigo"],
       "layer2.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-indigo/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_indigo"],
@@ -3733,9 +3736,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_indigo"],
@@ -3756,7 +3759,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_indigo"],
@@ -3766,7 +3769,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -3776,7 +3779,7 @@
       "layer3.texture": "Material Theme/assets/accent-indigo/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3786,7 +3789,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3796,7 +3799,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3806,7 +3809,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -3816,37 +3819,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-indigo/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_indigo"],
@@ -3854,9 +3857,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_indigo"],
@@ -3865,9 +3868,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_indigo"],
@@ -3875,123 +3878,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [92, 107, 192]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_indigo"],
       "layer0.texture": "Material Theme/assets/accent-indigo/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_indigo"],
       "viewport_color": [92, 107, 192, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_indigo"],
       "layer1.texture": "Material Theme/assets/accent-indigo/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -3999,9 +4002,9 @@
       "layer1.texture": "Material Theme/assets/accent-indigo/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_indigo"],
@@ -4009,121 +4012,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-indigo/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_indigo"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-indigo/folder_dup--hover.png"
     },
-  
+
   // Pink Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_pink"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-pink/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_pink"],
       "layer0.tint": [255, 64, 129],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_pink"],
       "layer0.tint": [255, 64, 129],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_pink"],
       "match_fg": [255, 64, 129],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_pink"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_pink", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-pink/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-pink/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_pink"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [255, 64, 129]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_pink"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [255, 64, 129]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_pink"],
       "layer2.texture": "Material Theme/assets/accent-pink/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-pink/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_pink"],
@@ -4150,9 +4153,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_pink"],
@@ -4173,7 +4176,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_pink"],
@@ -4183,7 +4186,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-pink/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -4193,7 +4196,7 @@
       "layer3.texture": "Material Theme/assets/accent-pink/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4203,7 +4206,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4213,7 +4216,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4223,7 +4226,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -4233,37 +4236,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-pink/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_pink"],
@@ -4271,9 +4274,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_pink"],
@@ -4282,9 +4285,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_pink"],
@@ -4292,123 +4295,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [255, 64, 129]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_pink"],
       "layer0.texture": "Material Theme/assets/accent-pink/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_pink"],
       "viewport_color": [255, 64, 129, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_pink"],
       "layer1.texture": "Material Theme/assets/accent-pink/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -4416,9 +4419,9 @@
       "layer1.texture": "Material Theme/assets/accent-pink/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_pink"],
@@ -4426,121 +4429,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-pink/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_pink"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-pink/folder_dup--hover.png"
     },
-  
+
   // Blue Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_blue"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-blue/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_blue"],
       "layer0.tint": [41, 121, 255],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_blue"],
       "layer0.tint": [41, 121, 255],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_blue"],
       "match_fg": [41, 121, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_blue"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_blue", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-blue/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-blue/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_blue"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [41, 121, 255]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_blue"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [41, 121, 255]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_blue"],
       "layer2.texture": "Material Theme/assets/accent-blue/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-blue/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_blue"],
@@ -4567,9 +4570,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_blue"],
@@ -4590,7 +4593,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_blue"],
@@ -4600,7 +4603,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-blue/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -4610,7 +4613,7 @@
       "layer3.texture": "Material Theme/assets/accent-blue/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4620,7 +4623,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4630,7 +4633,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4640,7 +4643,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -4650,37 +4653,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-blue/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_blue"],
@@ -4688,9 +4691,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_blue"],
@@ -4699,9 +4702,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_blue"],
@@ -4709,123 +4712,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [41, 121, 255]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_blue"],
       "layer0.texture": "Material Theme/assets/accent-blue/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_blue"],
       "viewport_color": [41, 121, 255, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_blue"],
       "layer1.texture": "Material Theme/assets/accent-blue/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -4833,9 +4836,9 @@
       "layer1.texture": "Material Theme/assets/accent-blue/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_blue"],
@@ -4843,121 +4846,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-blue/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_blue"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-blue/folder_dup--hover.png"
     },
-  
+
   // Cyan Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_cyan"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-cyan/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_cyan"],
       "layer0.tint": [0, 188, 212],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_cyan"],
       "layer0.tint": [0, 188, 212],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_cyan"],
       "match_fg": [0, 188, 212],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_cyan"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_cyan", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-cyan/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-cyan/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_cyan"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [0, 188, 212]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_cyan"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [0, 188, 212]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_cyan"],
       "layer2.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-cyan/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_cyan"],
@@ -4984,9 +4987,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_cyan"],
@@ -5007,7 +5010,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_cyan"],
@@ -5017,7 +5020,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -5027,7 +5030,7 @@
       "layer3.texture": "Material Theme/assets/accent-cyan/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5037,7 +5040,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5047,7 +5050,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5057,7 +5060,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -5067,37 +5070,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-cyan/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_cyan"],
@@ -5105,9 +5108,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_cyan"],
@@ -5116,9 +5119,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_cyan"],
@@ -5126,123 +5129,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [0, 188, 212]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_cyan"],
       "layer0.texture": "Material Theme/assets/accent-cyan/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_cyan"],
       "viewport_color": [0, 188, 212, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_cyan"],
       "layer1.texture": "Material Theme/assets/accent-cyan/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -5250,9 +5253,9 @@
       "layer1.texture": "Material Theme/assets/accent-cyan/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_cyan"],
@@ -5260,121 +5263,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-cyan/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_cyan"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-cyan/folder_dup--hover.png"
     },
-  
+
   // Bright Teal Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_bright-teal"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.tint": [100, 255, 218],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.tint": [100, 255, 218],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_bright-teal"],
       "match_fg": [100, 255, 218],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_bright-teal"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_bright-teal", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-bright-teal/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_bright-teal"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [100, 255, 218]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_bright-teal"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [100, 255, 218]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_bright-teal"],
       "layer2.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-bright-teal/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5401,9 +5404,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5424,7 +5427,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5434,7 +5437,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -5444,7 +5447,7 @@
       "layer3.texture": "Material Theme/assets/accent-bright-teal/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5454,7 +5457,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5464,7 +5467,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5474,7 +5477,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -5484,37 +5487,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5522,9 +5525,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5533,9 +5536,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5543,123 +5546,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [100, 255, 218]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_bright-teal"],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_bright-teal"],
       "viewport_color": [100, 255, 218, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_bright-teal"],
       "layer1.texture": "Material Theme/assets/accent-bright-teal/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -5667,9 +5670,9 @@
       "layer1.texture": "Material Theme/assets/accent-bright-teal/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_bright-teal"],
@@ -5677,121 +5680,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_bright-teal"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-bright-teal/folder_dup--hover.png"
     },
-  
+
   // Acid Lime Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_acid-lime"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.tint": [198, 255, 0],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.tint": [198, 255, 0],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_acid-lime"],
       "match_fg": [198, 255, 0],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_acid-lime"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_acid-lime", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-acid-lime/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_acid-lime"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [198, 255, 0]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_acid-lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [198, 255, 0]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_acid-lime"],
       "layer2.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-acid-lime/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5818,9 +5821,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5841,7 +5844,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5851,7 +5854,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -5861,7 +5864,7 @@
       "layer3.texture": "Material Theme/assets/accent-acid-lime/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5871,7 +5874,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5881,7 +5884,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5891,7 +5894,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -5901,37 +5904,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5939,9 +5942,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5950,9 +5953,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_acid-lime"],
@@ -5960,123 +5963,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [198, 255, 0]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_acid-lime"],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_acid-lime"],
       "viewport_color": [198, 255, 0, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_acid-lime"],
       "layer1.texture": "Material Theme/assets/accent-acid-lime/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -6084,9 +6087,9 @@
       "layer1.texture": "Material Theme/assets/accent-acid-lime/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_acid-lime"],
@@ -6094,121 +6097,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_acid-lime"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-acid-lime/folder_dup--hover.png"
     },
-  
+
   // Graphite Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_graphite"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-graphite/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_graphite"],
       "layer0.tint": [97, 97, 97],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_graphite"],
       "layer0.tint": [97, 97, 97],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_graphite"],
       "match_fg": [97, 97, 97],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_graphite"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_graphite", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-graphite/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-graphite/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_graphite"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [97, 97, 97]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_graphite"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [97, 97, 97]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_graphite"],
       "layer2.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-graphite/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_graphite"],
@@ -6235,9 +6238,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_graphite"],
@@ -6258,7 +6261,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_graphite"],
@@ -6268,7 +6271,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -6278,7 +6281,7 @@
       "layer3.texture": "Material Theme/assets/accent-graphite/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6288,7 +6291,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6298,7 +6301,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6308,7 +6311,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -6318,37 +6321,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-graphite/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_graphite"],
@@ -6356,9 +6359,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_graphite"],
@@ -6367,9 +6370,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_graphite"],
@@ -6377,123 +6380,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [97, 97, 97]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_graphite"],
       "layer0.texture": "Material Theme/assets/accent-graphite/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_graphite"],
       "viewport_color": [97, 97, 97, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_graphite"],
       "layer1.texture": "Material Theme/assets/accent-graphite/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -6501,9 +6504,9 @@
       "layer1.texture": "Material Theme/assets/accent-graphite/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_graphite"],
@@ -6511,121 +6514,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-graphite/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_graphite"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-graphite/folder_dup--hover.png"
     },
-  
+
   // Breaking Bad Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_brba"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-brba/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_brba"],
       "layer0.tint": [56, 142, 60],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_brba"],
       "layer0.tint": [56, 142, 60],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_brba"],
       "match_fg": [56, 142, 60],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_brba"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_brba", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-brba/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-brba/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_brba"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [56, 142, 60]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_brba"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [56, 142, 60]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_brba"],
       "layer2.texture": "Material Theme/assets/accent-brba/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-brba/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_brba"],
@@ -6652,9 +6655,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_brba"],
@@ -6675,7 +6678,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_brba"],
@@ -6685,7 +6688,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-brba/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -6695,7 +6698,7 @@
       "layer3.texture": "Material Theme/assets/accent-brba/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6705,7 +6708,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6715,7 +6718,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6725,7 +6728,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -6735,37 +6738,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-brba/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_brba"],
@@ -6773,9 +6776,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_brba"],
@@ -6784,9 +6787,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_brba"],
@@ -6794,123 +6797,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [56, 142, 60]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_brba"],
       "layer0.texture": "Material Theme/assets/accent-brba/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_brba"],
       "viewport_color": [56, 142, 60, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_brba"],
       "layer1.texture": "Material Theme/assets/accent-brba/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -6918,9 +6921,9 @@
       "layer1.texture": "Material Theme/assets/accent-brba/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_brba"],
@@ -6928,121 +6931,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-brba/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_brba"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-brba/folder_dup--hover.png"
     },
-  
+
   // Sky Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_sky"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-sky/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_sky"],
       "layer0.tint": [132, 255, 255],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_sky"],
       "layer0.tint": [132, 255, 255],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_sky"],
       "match_fg": [132, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_sky"],
       "color": [0, 0, 0, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_sky", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-sky/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-sky/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_sky"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [132, 255, 255]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_sky"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [132, 255, 255]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_sky"],
       "layer2.texture": "Material Theme/assets/accent-sky/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-sky/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_sky"],
@@ -7069,9 +7072,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_sky"],
@@ -7092,7 +7095,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_sky"],
@@ -7102,7 +7105,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-sky/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -7112,7 +7115,7 @@
       "layer3.texture": "Material Theme/assets/accent-sky/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7122,7 +7125,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7132,7 +7135,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7142,7 +7145,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -7152,37 +7155,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-sky/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_sky"],
@@ -7190,9 +7193,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_sky"],
@@ -7201,9 +7204,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_sky"],
@@ -7211,123 +7214,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [132, 255, 255]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_sky"],
       "layer0.texture": "Material Theme/assets/accent-sky/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_sky"],
       "viewport_color": [132, 255, 255, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_sky"],
       "layer1.texture": "Material Theme/assets/accent-sky/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -7335,9 +7338,9 @@
       "layer1.texture": "Material Theme/assets/accent-sky/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_sky"],
@@ -7345,121 +7348,121 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-sky/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_sky"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-sky/folder_dup--hover.png"
     },
-  
+
   // Tomato Accent Color
   // ===========================================================================
-  
+
     {
       "class": "panel_button_control",
       "settings": ["material_theme_accent_tomato"],
       "attributes": ["hover"],
       "layer0.texture": "Material Theme/assets/accent-tomato/overflow_menu--hover.png"
     },
-  
+
     // tooltip
-  
+
     {
       "class": "tool_tip_control",
       "settings": ["material_theme_accent_tomato"],
       "layer0.tint": [244, 67, 54],
     },
-  
+
     {
       "class": "progress_gauge_control",
       "settings": ["material_theme_accent_tomato"],
       "layer0.tint": [244, 67, 54],
     },
-  
+
     {
       "class": "auto_complete_label",
       "settings": ["material_theme_accent_tomato"],
       "match_fg": [244, 67, 54],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
     {
       "class": "tool_tip_label_control",
       "settings": ["material_theme_accent_tomato"],
       "color": [255, 255, 255, 255]
     },
-  
+
       // Sidebar tree highlight
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/tree_highlight.png",
     },
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_accent_tomato", "material_theme_bullet_tree_indicator"],
       "layer1.texture": "Material Theme/assets/accent-tomato/tree_highlight--bullet.png",
       "layer1.inner_margin": [22, 16, 0, 0]
     },
-  
+
       // Tabs
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/tab_current.png",
     },
-  
+
       // Tabs close button
-  
+
     {
       "class": "tab_close_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/close_icon--hover.png",
       "layer3.texture": "Material Theme/assets/accent-tomato/dirty_icon--hover.png"
     },
-  
+
       // Opened files
-  
+
     {
       "class": "close_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/close_icon--hover.png",
     },
-  
+
       // Dirty opened files
-  
+
     {
       "class": "close_button",
       "attributes": ["dirty"],
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/dirty_icon--hover.png",
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_tomato"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "color": [244, 67, 54]
     },
-  
+
     {
       "class": "sidebar_label",
       "settings": ["material_theme_accent_tomato"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
       "color": [244, 67, 54]
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_tomato"],
       "layer2.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
       "layer3.texture": "Material Theme/assets/accent-tomato/folder_opened--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_tomato"],
@@ -7486,9 +7489,9 @@
         "frame_time": 0.020,
       }
     },
-  
+
       // Folder loading
-  
+
     {
       "class": "icon_folder_loading",
       "settings": ["material_theme_accent_tomato"],
@@ -7509,7 +7512,7 @@
         "frame_time": 0.075,
       },
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_accent_tomato"],
@@ -7519,7 +7522,7 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
     },
-  
+
       // Arrow icon folder
     {
       "class": "icon_folder",
@@ -7529,7 +7532,7 @@
       "layer3.texture": "Material Theme/assets/accent-tomato/arrow_folder--opened.png",
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7539,7 +7542,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7549,7 +7552,7 @@
       "layer2.opacity": 1.0,
       "layer3.opacity": 0.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7559,7 +7562,7 @@
       "layer2.opacity": 0.0,
       "layer3.opacity": 1.0
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -7569,37 +7572,37 @@
       ],
       "layer1.texture": "Material Theme/assets/accent-tomato/arrow_folder--hover.png",
     },
-  
+
       // tab set scroll left | scroll right
-  
+
     {
       "class": "scroll_tabs_left_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/arrow_left--hover.png",
     },
-  
+
     {
       "class": "scroll_tabs_right_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/arrow_right--hover.png",
     },
-  
-  
+
+
     {
       "class": "fold_button_control",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/fold_right--hover.png",
     },
-  
+
     {
       "class": "fold_button_control",
       "attributes": ["expanded"],
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/fold_down--hover.png"
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_tomato"],
@@ -7607,9 +7610,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
       // Panel labels
-  
+
     {
       "class": "quick_panel_label",
       "settings": ["material_theme_accent_tomato"],
@@ -7618,9 +7621,9 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
       // Panels sublabels
-  
+
     {
       "class": "quick_panel_path_label",
       "settings": ["material_theme_accent_tomato"],
@@ -7628,123 +7631,123 @@
       "selected_fg": [255, 255, 255, 255],
       "selected_match_fg": [244, 67, 54]
     },
-  
+
       // Panels data / score
-  
+
     {
       "class": "show_tabs_dropdown_button",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/overflow_menu--hover.png",
     },
-  
+
       // Textline input oveflow menu
-  
+
     {
       "class": "dropdown_button_control",
       "settings": ["material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/overflow_menu--hover.png",
     },
-  
+
     // Buttons icons settings
     // =====================================================================
-  
+
       // Regex Icon
     {
       "class": "icon_regex",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_regex--hover.png",
     },
-  
+
       // Preserve case sensitive
-  
+
     {
       "class": "icon_case",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_case--hover.png",
     },
-  
+
       // Wholeword
-  
+
     {
       "class": "icon_whole_word",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_word--hover.png",
     },
-  
+
       // Wrap
-  
+
     {
       "class": "icon_wrap",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_wrap--hover.png",
     },
-  
+
       // In selection
-  
+
     {
       "class": "icon_in_selection",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_inselection--hover.png",
     },
-  
-  
+
+
       // Highlight Result
-  
+
     {
       "class": "icon_highlight",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_highlight--hover.png",
     },
-  
+
       // Preserve Case
-  
+
     {
       "class": "icon_preserve_case",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/replace_preserve_case--hover.png",
     },
-  
+
       // Show context
-  
+
     {
       "class": "icon_context",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_context--hover.png",
     },
-  
+
       // Use buffer
-  
+
     {
       "class": "icon_use_buffer",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/use_buffer--hover.png",
     },
-  
+
       // Reverse direction
-  
+
     {
       "class": "icon_reverse",
       "settings": ["material_theme_accent_tomato"],
       "layer0.texture": "Material Theme/assets/accent-tomato/find_reverse--hover.png",
     },
-  
+
       // Minimap
-  
+
     {
       "class": "minimap_control",
       "settings": ["material_theme_accent_tomato"],
       "viewport_color": [244, 67, 54, 60]
     },
-  
+
       // Scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_accent_scrollbars", "material_theme_accent_tomato"],
       "layer1.texture": "Material Theme/assets/accent-tomato/thumb_vertical.png",
       "layer1.opacity": 0.8
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -7752,9 +7755,9 @@
       "layer1.texture": "Material Theme/assets/accent-tomato/thumb_horizontal.png",
       "layer1.opacity": 0.8
     },
-  
+
     // Symlink folder icon
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_tomato"],
@@ -7762,47 +7765,47 @@
       [{ "class": "tree_row", "attributes": ["hover"] }],
       "layer0.texture": "Material Theme/assets/accent-tomato/folder_dup--hover.png"
     },
-  
+
     {
       "class": "icon_folder_dup",
       "settings": ["material_theme_accent_tomato"],
       "parents": [{"class": "tree_row", "attributes": ["expanded"] }],
       "layer0.texture": "Material Theme/assets/accent-tomato/folder_dup--hover.png"
     },
-  
-  
-  
+
+
+
   // @ THEME OPTIONS
   // Options override
   // =========================================================================
-  
+
     // Tabs size Settings
-  
+
     {
       "class": "tabset_control",
       "settings": ["material_theme_small_tab"],
       "tab_height": 36,
       "content_margin": [12, 0, 8, 0]
     },
-  
+
     {
       "class": "tabset_control",
       "settings": ["material_theme_tabs_autowidth"],
       "tab_width": 0
     },
-  
+
     {
       "class": "tabset_control",
       "settings": ["!enable_tab_scrolling"],
       "content_margin": [0, 0, 8, 0],
     },
-  
+
     {
       "class": "tab_control",
       "settings": ["material_theme_small_tab"],
       "content_margin": [12, 8, 6, 4],
     },
-  
+
     // Tabs separator
     {
       "class": "tab_control",
@@ -7811,17 +7814,17 @@
       "layer3.inner_margin": [1, 1],
       "layer3.opacity": 1.0,
     },
-  
+
       // Tab Labels
-  
+
     {
       "class": "tab_label",
       "settings": ["material_theme_bold_tab"],
       "font.bold": true
     },
-  
+
       // Disable Folder animation
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation"],
@@ -7830,9 +7833,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/commons/folder--hover.png",
     },
-  
+
       // Disable Folder animation
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders"],
@@ -7841,11 +7844,11 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/commons/arrow_folder--opened.png",
     },
-  
+
       // Folder hover no animation
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_lime"],
@@ -7854,7 +7857,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-lime/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_lime"],
@@ -7863,9 +7866,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-lime/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_purple"],
@@ -7874,7 +7877,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-purple/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_purple"],
@@ -7883,9 +7886,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-purple/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_red"],
@@ -7894,7 +7897,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-red/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_red"],
@@ -7903,9 +7906,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-red/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_orange"],
@@ -7914,7 +7917,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-orange/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_orange"],
@@ -7923,9 +7926,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-orange/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_yellow"],
@@ -7934,7 +7937,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_yellow"],
@@ -7943,9 +7946,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-yellow/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_indigo"],
@@ -7954,7 +7957,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_indigo"],
@@ -7963,9 +7966,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-indigo/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_pink"],
@@ -7974,7 +7977,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-pink/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_pink"],
@@ -7983,9 +7986,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-pink/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_blue"],
@@ -7994,7 +7997,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-blue/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_blue"],
@@ -8003,9 +8006,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-blue/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_cyan"],
@@ -8014,7 +8017,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_cyan"],
@@ -8023,9 +8026,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-cyan/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_bright-teal"],
@@ -8034,7 +8037,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_bright-teal"],
@@ -8043,9 +8046,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-bright-teal/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_acid-lime"],
@@ -8054,7 +8057,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_acid-lime"],
@@ -8063,9 +8066,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-acid-lime/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_graphite"],
@@ -8074,7 +8077,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_graphite"],
@@ -8083,9 +8086,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-graphite/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_brba"],
@@ -8094,7 +8097,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-brba/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_brba"],
@@ -8103,9 +8106,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-brba/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_sky"],
@@ -8114,7 +8117,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-sky/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_sky"],
@@ -8123,9 +8126,9 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-sky/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_accent_tomato"],
@@ -8134,7 +8137,7 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
     },
-  
+
     {
       "class": "icon_folder",
       "settings": ["material_theme_disable_folder_animation", "material_theme_arrow_folders", "material_theme_accent_tomato"],
@@ -8143,26 +8146,26 @@
       "layer2.opacity": 0.0,
       "layer3.texture": "Material Theme/assets/accent-tomato/arrow_folder--opened.png",
     },
-  
-    
-  
+
+
+
       // Small status bar
-  
+
     {
       "class": "status_container",
       "settings": ["material_theme_small_statusbar"],
       "content_margin": [12, 6, 12, 6],
     },
-  
+
       // Tree Indicator
-  
+
     {
       "class": "tree_row",
       "settings": ["material_theme_disable_tree_indicator"],
       "attributes": ["selected"],
       "layer1.opacity": 0.0
     },
-  
+
     // Status bar panel
     {
       "class": "panel_control",
@@ -8171,74 +8174,74 @@
       "layer1.opacity": 0.2,
       "layer1.inner_margin": [2, 2, 2, 2],
     },
-  
+
       // Contrast mode
-  
+
     {
       "class": "sidebar_container",
       "settings": ["material_theme_contrast_mode"],
       "layer1.opacity": 0.2
     },
-  
+
     {
       "class": "sidebar_tree",
       "settings": ["material_theme_contrast_mode"],
       "layer1.opacity": 0.2
     },
-  
+
     {
       "class": "status_bar",
       "settings": ["material_theme_contrast_mode"],
       "layer1.opacity": 0.2
     },
-  
+
       // Compact mode
-  
+
     {
       "class": "sidebar_tree",
       "settings": ["material_theme_compact_sidebar"],
       "row_padding": [24, 5]
     },
-  
+
     {
       "class": "panel_control",
       "settings": ["material_theme_compact_panel"],
       "content_margin": [0, 0, 0, 0],
     },
-  
+
       // Filetype icons in sidebar
-  
+
     {
       "class": "icon_file_type",
       "settings": ["material_theme_disable_fileicons"],
       "layer0.opacity": 0,
       "content_margin": [0, 0]
     },
-  
+
       // Bigger file_type icons
-  
+
     {
       "class": "icon_file_type",
       "settings": ["material_theme_big_fileicons"],
       "content_margin": [11, 11]
     },
-  
+
     {
       "class": "icon_file_type",
       "settings": ["material_theme_big_fileicons"],
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "content_margin": [11, 11]
     },
-  
+
         // Bright scrollbars
-  
+
     {
       "class": "puck_control",
       "settings": ["material_theme_bright_scrollbars"],
       "layer1.texture": "Material Theme/assets/commons/thumb_vertical.png",
       "layer1.opacity": 0.2
     },
-  
+
     {
       "class": "puck_control",
       "attributes": ["horizontal"],
@@ -8246,9 +8249,9 @@
       "layer1.texture": "Material Theme/assets/commons/thumb_horizontal.png",
       "layer1.opacity": 0.2
     },
-  
+
       // Title bar (OS X 10.10+)
-  
+
     {
       "class": "title_bar",
       "settings": ["material_theme_titlebar"],
@@ -8256,214 +8259,214 @@
       "fg": [96, 125, 139],
       "bg": [38, 50, 56]
     },
-  
+
     {
       "class": "title_bar",
       "settings": ["material_theme_titlebar", "material_theme_contrast_mode"],
       "platforms": ["osx"],
       "fg": [96, 125, 139],
       "bg":
-        
+
           [30, 40, 45]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_lime", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [124, 179, 66],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_purple", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [171, 71, 188],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_red", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [229, 115, 115],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_orange", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [255, 112, 66],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_yellow", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [255, 160, 0],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_indigo", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [92, 107, 192],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_pink", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [255, 64, 129],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_blue", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [41, 121, 255],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_cyan", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [0, 188, 212],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_bright-teal", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [100, 255, 218],
       "fg":
-        
+
           [0, 0, 0]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_acid-lime", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [198, 255, 0],
       "fg":
-        
+
           [0, 0, 0]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_graphite", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [97, 97, 97],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_brba", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [56, 142, 60],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_sky", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [132, 255, 255],
       "fg":
-        
+
           [0, 0, 0]
-        
+
     },
-  
-    
-  
+
+
+
     {
       "class": "title_bar",
       "settings": ["material_theme_accent_titlebar", "material_theme_accent_tomato", "material_theme_titlebar"],
       "platforms": ["osx"],
       "bg": [244, 67, 54],
       "fg":
-        
+
           [255, 255, 255]
-        
+
     },
-  
-    
-  
+
+
+
   //
 ]


### PR DESCRIPTION
#### Description
Added dark title bar to default and darker theme and I also fixed link color in package control install dialog. Other changes are just removed trailing spaces.

I tried to find good alternative and even create custom theme but there is no such a nice theme similar to this and is easier to fix this.

Note: Appbar https://github.com/equinusocio/material-theme-appbar has also been removed so maybe re-add or remove it from the package control.

#### Motivation and Context
It looks better than standard white.

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/11664877/205453164-a8046be9-b17c-47f3-83c6-fdab5d47cfa7.png)

![image](https://user-images.githubusercontent.com/11664877/205453289-f0bbe22b-026f-4049-956d-9eb52f8f136d.png)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
