### PR TITLE
Strip development sources/utils from sublime-packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# git
+.github/ export-ignore
+gh-pages/ export-ignore
+*.git export-ignore
+*.gitignore export-ignore
+*.gitattributes export-ignore
+
+# build tools
+.gulp/ export-ignore
+.babelrc export-ignore
+.editorconfig export-ignore
+.eslintrc.yml export-ignore
+.flake8 export-ignore
+.travis.yml export-ignore
+gulpfile.babel.js export-ignore
+package-lock.json export-ignore
+package.json export-ignore
+
+# development sources
+sources/ export-ignore
+test/ export-ignore


### PR DESCRIPTION
To rule out any concern about shipping dangerous sources, this PR proposes to exclude all kinds of development sources and utils from sublime-package files.