### PR TITLE
When a file is ignored by the VCS, the file name will be displayed in gray

### DIFF
--- a/sources/themes/darker/sidebar.json
+++ b/sources/themes/darker/sidebar.json
@@ -77,6 +77,13 @@
 
   {
     "class": "sidebar_label",
+    "parents": [{"class": "file_system_entry", "attributes": ["ignored"]}],
+    "font.bold": false,
+    "color": [60, 60, 60]
+  },
+
+  {
+    "class": "sidebar_label",
     "parents": [{"class": "tree_row", "attributes": ["hover"]}],
     "color": [255, 255, 255],
     "shadow_color": [255, 255, 255, 0],

--- a/sources/themes/default/sidebar.json
+++ b/sources/themes/default/sidebar.json
@@ -78,6 +78,13 @@
 
   {
     "class": "sidebar_label",
+    "parents": [{"class": "file_system_entry", "attributes": ["ignored"]}],
+    "font.bold": false,
+    "color": [80, 80, 80]
+  },
+
+  {
+    "class": "sidebar_label",
     "parents": [{"class": "tree_row", "attributes": ["hover"]}],
     "color": [255,255,255],
     "shadow_color": [255, 255, 255, 0],

--- a/sources/themes/lighter/sidebar.json
+++ b/sources/themes/lighter/sidebar.json
@@ -77,6 +77,13 @@
 
   {
     "class": "sidebar_label",
+    "parents": [{"class": "file_system_entry", "attributes": ["ignored"]}],
+    "font.bold": false,
+    "color": [222, 222, 222]
+  },
+
+  {
+    "class": "sidebar_label",
     "parents": [{"class": "tree_row", "attributes": ["hover"]}],
     "color": [144, 164, 174],
     "shadow_color": [255, 255, 255, 0],

--- a/sources/themes/palenight/sidebar.json
+++ b/sources/themes/palenight/sidebar.json
@@ -78,6 +78,13 @@
 
   {
     "class": "sidebar_label",
+    "parents": [{"class": "file_system_entry", "attributes": ["ignored"]}],
+    "font.bold": false,
+    "color": [80, 80, 80]
+  },
+
+  {
+    "class": "sidebar_label",
     "parents": [{"class": "tree_row", "attributes": ["hover"]}],
     "color": [255, 255, 255],
     "shadow_color": [255, 255, 255, 0],


### PR DESCRIPTION
#### Description
support VCS status in siderbar (sorry there's a typo in my commit message, not "VSC")

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Sublime Text support VCS status by default (e.g ignored file will be lighter than normal files), other themes such as ayu also support it. not Material Theme. 


#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
I didn't build from source code to test, I directly modified files in Material Theme.sublime-package, including all `Material-Theme-*.sublime-theme` file.


#### Screenshots (if appropriate):

before

<img width="172" alt="before" src="https://github.com/SublimeText/material-theme/assets/8928155/ba78e506-c116-4cb1-961b-9a9a3dab83ef">

after

<img width="182" alt="after" src="https://github.com/SublimeText/material-theme/assets/8928155/a5c56710-f558-444f-a8a9-690acaf9a39f">


#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
