### PR TITLE
Strip obsolete dependencies

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,13 +1,7 @@
 {
-  "*": {
-    ">=3114": [
-      "markupsafe",
-      "mdpopups",
-      "pygments",
-      "pymdownx",
-      "python-jinja2",
-      "python-markdown",
-      "pyyaml"
-    ]
-  }
+	"*": {
+		">=3114": [
+			"mdpopups"
+		]
+	}
 }

--- a/utils/info.py
+++ b/utils/info.py
@@ -56,24 +56,6 @@ class MtInfoCommand(sublime_plugin.ApplicationCommand):
         except Exception:
             info["mdpopups_version"] = 'Version could not be acquired!'
 
-        try:
-            import markdown
-            info["markdown_version"] = format_version(markdown, 'version')
-        except Exception:
-            info["markdown_version"] = 'Version could not be acquired!'
-
-        try:
-            import jinja2
-            info["jinja_version"] = format_version(jinja2, '__version__')
-        except Exception:
-            info["jinja_version"] = 'Version could not be acquired!'
-
-        try:
-            import pygments
-            info["pygments_version"] = format_version(pygments, '__version__')
-        except Exception:
-            info["pygments_version"] = 'Version could not be acquired!'
-
         msg = textwrap.dedent(
             """\
             - Sublime Text:   %(version)s
@@ -83,9 +65,6 @@ class MtInfoCommand(sublime_plugin.ApplicationCommand):
             - Install via PC:   %(pc_install)s
             - Dependencies:
                 * mdpopups:   %(mdpopups_version)s
-                * markdown:   %(markdown_version)s
-                * pygments:   %(pygments_version)s
-                * jinja2:   %(jinja_version)s
             """ % info
         )
 


### PR DESCRIPTION
#### Description

mdpopups vendors all libraries it needs, so all others can be removed.

#### Motivation and Context

Reduce number of libraries need to be installed alongside with this package.

#### How Has This Been Tested?

Removed all dependencies, which have no reference in code.

Installed and run configuration popup in vanilla ST environment with only PC4.0, mdpopups and Marterial Theme installed.

#### Screenshots (if appropriate):

#### Types of changes

- maintanance

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
